### PR TITLE
Support for arrayOf(schema)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@
  * @returns undefined
  */
 
-import { normalize, Schema } from 'normalizr';
+import { normalize, Schema, arrayOf } from 'normalizr';
 import fetch from 'isomorphic-fetch';
 import isPlainObject from 'lodash.isplainobject';
 
@@ -120,7 +120,7 @@ export function isRSAA(action) {
     ~validMethods.indexOf(method.toUpperCase()) &&
     (Array.isArray(types) && types.length === 3) &&
     (typeof headers === 'undefined' || isPlainObject(headers)) &&
-    (typeof schema === 'undefined' || schema instanceof Schema) &&
+    (typeof schema === 'undefined' || schema instanceof Schema || schema.hasOwnProperty('_itemSchema')) &&
     (typeof bailout === 'undefined' || typeof bailout === 'boolean' || typeof bailout === 'function');
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,7 @@
  * @returns undefined
  */
 
-import { normalize, Schema, arrayOf } from 'normalizr';
+import { normalize, Schema } from 'normalizr';
 import fetch from 'isomorphic-fetch';
 import isPlainObject from 'lodash.isplainobject';
 

--- a/test/index.js
+++ b/test/index.js
@@ -71,6 +71,17 @@ test('isRSAA must identify RSAA-compliant actions', function (t) {
       schema: new Schema('key'),
       bailout: ''
     }
+  }), '[CALL_API].schema can also be an array of schemas');
+  t.notOk(isRSAA({
+    [CALL_API]: {
+      endpoint: '',
+      method: 'GET',
+      types: ['REQUEST', 'SUCCESS', 'FAILURE'],
+      body: {},
+      headers: {},
+      schema: arrayOf(new Schema('key')),
+      bailout: ''
+    }
   }), '[CALL_API].bailout must be a boolean or a function');
   t.ok(isRSAA({
     [CALL_API]: {
@@ -294,6 +305,59 @@ test('apiMiddleware must process a successful API response with a schema when pr
       method: 'GET',
       types: ['FETCH_USER.REQUEST', 'FETCH_USER.SUCCESS', 'FETCH_USER.FAILURE'],
       schema: userSchema
+    }
+  };
+  const doGetState = () => {};
+  const nextHandler = apiMiddleware({ getState: doGetState });
+  const doNext = (action) => {
+    switch (action.type) {
+    case 'FETCH_USER.SUCCESS':
+      t.deepEqual(action.payload.entities, entities, 'success FSA has correct payload property');
+      break;
+    }
+  };
+  const actionHandler = nextHandler(doNext);
+
+  t.plan(1);
+  actionHandler(anAction);
+});
+
+test('apiMiddleware must process a successful API response with an array of schemas when present', function (t) {
+  const testList = [
+    {
+      id: 1,
+      username: 'Alice',
+    }, 
+    {
+      id: 2,
+      username: 'Bob'
+    }
+  ];
+  
+  const userSchema = new Schema('users');
+  
+  const entities = {
+    users : {
+      1: {
+        id: 1,
+        username: 'Alice'
+      },
+      2: {
+        id: 2,
+        username: 'Bob'
+      }
+    }
+  };
+
+  const api = nock('http://127.0.0.1')
+                .get('/api/users/1')
+                .reply(200, testList, {'Content-Type': 'application/json'});
+  const anAction = {
+    [CALL_API]: {
+      endpoint: 'http://127.0.0.1/api/users/1',
+      method: 'GET',
+      types: ['FETCH_USER.REQUEST', 'FETCH_USER.SUCCESS', 'FETCH_USER.FAILURE'],
+      schema: arrayOf(userSchema)
     }
   };
   const doGetState = () => {};


### PR DESCRIPTION
This adds support for schema arrays in Normalizr. This way of referencing is supported by Normalizr and used in the [official redux example](https://github.com/rackt/redux/blob/master/examples/real-world/middleware/api.js#L68), so I think it would be useful here.