### PR TITLE
Proposal: Include response object in Error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ import isPlainObject from 'lodash.isplainobject';
  *
  * @class ApiError
  * @access private
- * @param {} status - the status code of the API response
+ * @param {number} status - the status code of the API response
  * @param {string} statusText - the status text of the API response
  * @param {Object} response - the JSON response of the API server if the 'Content-Type'
  *  header signals a JSON response, or the raw response object otherwise
@@ -96,7 +96,7 @@ function callApi(endpoint, method, headers, body, schema) {
 }
 
 /**
- * Action key that carries API call info interpreted by this Redux middleware.
+ * Symbol key that carries API call info interpreted by this Redux middleware.
  *
  * @constant {Symbol}
  * @access public
@@ -109,7 +109,7 @@ export const CALL_API = Symbol('Call API');
  *
  * @function isRSAA
  * @access public
- * @param action - The action to check against the RSAA definition.
+ * @param {Object} action - The action to check against the RSAA definition.
  * @returns {boolean}
  */
 export function isRSAA(action) {

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,16 @@ import { normalize, Schema } from 'normalizr';
 import fetch from 'isomorphic-fetch';
 import isPlainObject from 'lodash.isplainobject';
 
+export class ApiError extends Error {
+  constructor(response) {
+    var s = super(`${response.status} - ${response.statusText}`);
+    this.message = s.message;
+    this.stack = s.stack;
+    this.name = 'ApiError';
+    this.response = response;
+  }
+}
+
 /**
  * Fetches an API response and normalizes the resulting JSON according to schema.
  *
@@ -45,7 +55,7 @@ function callApi(endpoint, method, headers, body, schema) {
       if (response.ok) {
         return Promise.resolve(response);
       } else {
-        return Promise.reject(new Error(`${response.status} - ${response.statusText}`));
+        return Promise.reject(new ApiError(response));
       }
     })
     .then(response => {

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@ import test from 'tape';
 import { Schema, arrayOf } from 'normalizr';
 import nock from 'nock';
 
-import { CALL_API, apiMiddleware, isRSAA} from '../src';
+import { CALL_API, apiMiddleware, isRSAA, ApiError } from '../src';
 
 test('isRSAA must identify RSAA-compliant actions', function (t) {
   t.notOk(isRSAA(''), 'RSAA actions must be plain JavaScript objects');
@@ -246,7 +246,9 @@ test('apiMiddleware must handle an unsuccessful API request', function (t) {
     case 'FETCH_USER.FAILURE':
       t.pass('failure FSA action passed to the next handler');
       t.equal(typeof action[CALL_API], 'undefined', 'failure FSA does not have a [CALL_API] property')
-      t.ok(action.payload instanceof Error, 'failure FSA has correct payload property');
+      t.ok(action.payload instanceof ApiError, 'failure FSA has correct payload property');
+      t.ok(action.payload.response instanceof Object, 'failure FSA error object includes the response object');
+      t.equal(action.payload.message, '404 - Not Found');
       t.deepEqual(action.meta, anAction.meta, 'failure FSA has correct meta property');
       t.ok(action.error, 'failure FSA has correct error property');
       break;
@@ -254,7 +256,7 @@ test('apiMiddleware must handle an unsuccessful API request', function (t) {
   };
   const actionHandler = nextHandler(doNext);
 
-  t.plan(10);
+  t.plan(12);
   actionHandler(anAction);
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -141,6 +141,49 @@ test('apiMiddleware must pass non-RSAA actions to the next handler', function (t
   actionHandler(nonRSAAAction);
 });
 
+test('apiMiddleware must handle an unsuccessful API request with a json response', function (t) {
+  const api = nock('http://127.0.0.1')
+                .get('/api/users/1')
+                .reply(404, { error: 'API error' }, { 'Content-Type': 'application/json' });
+  const anAction = {
+    [CALL_API]: {
+      endpoint: 'http://127.0.0.1/api/users/1',
+      method: 'GET',
+      types: ['FETCH_USER.REQUEST', 'FETCH_USER.SUCCESS', 'FETCH_USER.FAILURE']
+    },
+    payload: { someKey: 'someValue' },
+    meta: 'meta'
+  };
+  const doGetState = () => {};
+  const nextHandler = apiMiddleware({ getState: doGetState });
+  const doNext = (action) => {
+    switch (action.type) {
+    case 'FETCH_USER.REQUEST':
+      t.pass('request FSA passed to the next handler');
+      t.equal(typeof action[CALL_API], 'undefined', 'request FSA does not have a [CALL_API] property')
+      t.deepEqual(action.payload, anAction.payload, 'request FSA has correct payload property');
+      t.deepEqual(action.meta, anAction.meta, 'request FSA has correct meta property');
+      t.notOk(action.error, 'request FSA has correct error property');
+      break;
+    case 'FETCH_USER.FAILURE':
+      t.pass('failure FSA action passed to the next handler');
+      t.equal(typeof action[CALL_API], 'undefined', 'failure FSA does not have a [CALL_API] property')
+      t.equal(action.payload.name, 'ApiError', 'failure FSA has an ApiError payload');
+      t.equal(action.payload.status, 404, 'failure FSA has an ApiError payload with the correct status code');
+      t.equal(action.payload.statusText, 'Not Found', 'failure FSA has an ApiError payload with the correct status text');
+      t.equal(action.payload.message, '404 - Not Found', 'failure FSA has an ApiError payload with the correct message');
+      t.equal(action.payload.response.error, 'API error', 'failure FSA has an ApiError payload with the correct json response');
+      t.deepEqual(action.meta, anAction.meta, 'failure FSA has correct meta property');
+      t.ok(action.error, 'failure FSA has correct error property');
+      break;
+    }
+  };
+  const actionHandler = nextHandler(doNext);
+
+  t.plan(14);
+  actionHandler(anAction);
+});
+
 test('apiMiddleware must handle a successful API request', function (t) {
   const api = nock('http://127.0.0.1')
                 .get('/api/users/1')
@@ -216,49 +259,6 @@ test('apiMiddleware must handle a successful API request that returns an empty b
   const actionHandler = nextHandler(doNext);
 
   t.plan(10);
-  actionHandler(anAction);
-});
-
-test('apiMiddleware must handle an unsuccessful API request with a json response', function (t) {
-  const api = nock('http://127.0.0.1')
-                .get('/api/users/1')
-                .reply(404, { error: 'API error' }, { 'Content-Type': 'application/json' });
-  const anAction = {
-    [CALL_API]: {
-      endpoint: 'http://127.0.0.1/api/users/1',
-      method: 'GET',
-      types: ['FETCH_USER.REQUEST', 'FETCH_USER.SUCCESS', 'FETCH_USER.FAILURE']
-    },
-    payload: { someKey: 'someValue' },
-    meta: 'meta'
-  };
-  const doGetState = () => {};
-  const nextHandler = apiMiddleware({ getState: doGetState });
-  const doNext = (action) => {
-    switch (action.type) {
-    case 'FETCH_USER.REQUEST':
-      t.pass('request FSA passed to the next handler');
-      t.equal(typeof action[CALL_API], 'undefined', 'request FSA does not have a [CALL_API] property')
-      t.deepEqual(action.payload, anAction.payload, 'request FSA has correct payload property');
-      t.deepEqual(action.meta, anAction.meta, 'request FSA has correct meta property');
-      t.notOk(action.error, 'request FSA has correct error property');
-      break;
-    case 'FETCH_USER.FAILURE':
-      t.pass('failure FSA action passed to the next handler');
-      t.equal(typeof action[CALL_API], 'undefined', 'failure FSA does not have a [CALL_API] property')
-      t.equal(action.payload.name, 'ApiError', 'failure FSA has an ApiError payload');
-      t.equal(action.payload.status, 404, 'failure FSA has an ApiError payload with the correct status code');
-      t.equal(action.payload.statusText, 'Not Found', 'failure FSA has an ApiError payload with the correct status text');
-      t.equal(action.payload.message, '404 - Not Found', 'failure FSA has an ApiError payload with the correct message');
-      t.equal(action.payload.response.error, 'API error', 'failure FSA has an ApiError payload with the correct json response');
-      t.deepEqual(action.meta, anAction.meta, 'failure FSA has correct meta property');
-      t.ok(action.error, 'failure FSA has correct error property');
-      break;
-    }
-  };
-  const actionHandler = nextHandler(doNext);
-
-  t.plan(14);
   actionHandler(anAction);
 });
 


### PR DESCRIPTION
Currently, when a call fails, a new Error is created:

```js
return Promise.reject(new Error(`${response.status} - ${response.statusText}`));
```

However, especially for backends that return json responses, the response itself may be useful as it contains some error information, possibly along the lines of, e.g.:

```js
{ "error": "my custom error message" }
```

It would be useful if there was some way to pass on the entire response so that the caller can then deal with it as necesary (and redux-api-middleware is agnostic to this). My idea was to create a new ApiError class that extends Error with an additional field `response`. The middleware can then fail calls with:

```js
return Promise.reject(new ApiError(response));
```