### PR TITLE
Add babel-runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,7 @@
 {
   "stage": 0,
-  "loose": "all"
+  "loose": "all",
+  "optional": [
+    "runtime"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "babel-runtime": "^5.8.25",
     "isomorphic-fetch": "^2.1.1",
     "lodash.isplainobject": "^3.2.0"
   },


### PR DESCRIPTION
The `regeneratorRuntime` module (which is provided by `babel-runtime`) is required by the compiled output because of the use of async / await.