### PR TITLE
Stringify body before calling the API

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -100,7 +100,13 @@ function apiMiddleware({ getState }) {
 
     try {
       // Make the API call
-      var res = await fetch(endpoint, { method, body, credentials, headers });
+      var res = await fetch(endpoint, { 
+        method,
+        // Stringify body if needed
+        body: typeof body === 'string' ? body : JSON.stringify(body),
+        credentials,
+        headers
+      });
     } catch(e) {
       // The request was malformed, or there was a network error
       return next(await actionWith(

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -103,7 +103,7 @@ function apiMiddleware({ getState }) {
       var res = await fetch(endpoint, { 
         method,
         // Stringify body if needed
-        body: typeof body === 'string' ? body : JSON.stringify(body),
+        body: typeof body === 'undefined' || typeof body === 'string' ? body : JSON.stringify(body),
         credentials,
         headers
       });


### PR DESCRIPTION
I find myself frequently setting body to a JSON object. However, the `body` in `fetch(endpoint, {body})` must be a string.

This pull request converts the `body` to a string when it is not already `typeof body === 'undefined'` or `typeof body === 'string'`.

In the case `JSON.stringify(body)` throws, the failure FSA will be dispatched. And error would have been thrown anyways because the `fetch(...)` would have failed.