### PR TITLE
Don't attempt to parse 204 & 205

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -10,8 +10,9 @@ import { InternalError, ApiError } from './errors';
  */
 async function getJSON(res) {
   const contentType = res.headers.get('Content-Type');
+  const emptyCodes = [204, 205];
 
-  if (contentType && ~contentType.indexOf('json')) {
+  if (!~emptyCodes.indexOf(res.status) && contentType && ~contentType.indexOf('json')) {
     return await res.json();
   } else {
     return await Promise.resolve();


### PR DESCRIPTION
`res.json` throws InternalError: "Unexpected end of input" if the response if blank.

Modified `getJSON` will skip parsing JSON response if the response status is either "No Content" or "Reset Content". Presence of `Content-Type` header does not imply presence of response body, therefore it is unsafe to rely on it.