### PR TITLE
Allow a `fetch` function to be passed into apiMiddleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 redux-api-middleware
 ====================
+![deprecated](https://cloud.githubusercontent.com/assets/1039473/22737318/9c125686-edd0-11e6-88fb-231cd4397ac9.png)
 
 [![Build Status](https://travis-ci.org/agraboso/redux-api-middleware.svg?branch=master)](https://travis-ci.org/agraboso/redux-api-middleware) [![Coverage Status](https://coveralls.io/repos/agraboso/redux-api-middleware/badge.svg?branch=master&service=github)](https://coveralls.io/github/agraboso/redux-api-middleware?branch=master)
 
 [Redux middleware](http://rackt.github.io/redux/docs/advanced/Middleware.html) for calling an API.
+
 
 ## Table of contents
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "dependencies": {
     "babel-runtime": "^5.8.25",
     "isomorphic-fetch": "^2.1.1",
-    "lodash.isplainobject": "^3.2.0"
+    "lodash.isplainobject": "^3.2.0",
+    "lodash.isfunction": "3.0.8"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,5 +1,6 @@
-import fetch from 'isomorphic-fetch';
+import isomorphicFetch from 'isomorphic-fetch';
 import isPlainObject from 'lodash.isplainobject';
+import isFunction from 'lodash.isfunction';
 
 import CALL_API from './CALL_API';
 import { isRSAA, validateRSAA } from './validation';
@@ -12,7 +13,14 @@ import { getJSON, normalizeTypeDescriptors, actionWith } from './util';
  * @type {ReduxMiddleware}
  * @access public
  */
-function apiMiddleware({ getState }) {
+let fetch = isomorphicFetch;
+function apiMiddleware(storeOrFetch) {
+  if (isFunction(storeOrFetch)) {
+    fetch = storeOrFetch;
+    return apiMiddleware;
+  }
+  const { getState } = storeOrFetch;
+
   return (next) => async (action) => {
     // Do not process actions without a [CALL_API] property
     if (!isRSAA(action)) {

--- a/test/index.js
+++ b/test/index.js
@@ -1662,3 +1662,63 @@ test('apiMiddleware must dispatch a failure FSA on an unsuccessful API call with
   t.plan(8);
   actionHandler(anAction);
 });
+
+test('apiMiddleware must allow fetch to be passed in', t => {
+  const anAction = {
+    [CALL_API]: {
+      endpoint: 'http://127.0.0.1/api/users/1',
+      method: 'GET',
+      types: ['REQUEST', 'SUCCESS', 'FAILURE'],
+      body: {
+        some: 'arbitrary JSON'
+      },
+      credentials: 'include',
+      headers: {
+        'X-Testing-Header': 'yeah'
+      }
+    }
+  };
+  const mockFetch = (endpoint, { method, body, credentials, headers }) => {
+    t.pass('apiMiddleware executed the passed-in fetch');
+    t.equal(
+      endpoint,
+      'http://127.0.0.1/api/users/1',
+      'passed-in fetch executed with proper endpoint'
+    );
+    t.equal(
+      method,
+      'GET',
+      'passed-in fetch executed with proper method'
+    );
+    t.deepEqual(
+      body,
+      { some: 'arbitrary JSON' },
+      'passed-in fetch executed with proper body'
+    );
+    t.equal(
+      credentials,
+      'include',
+      'passed-in fetch executed with proper credentials'
+    );
+    t.deepEqual(
+      headers,
+      { 'X-Testing-Header': 'yeah' },
+      'passed-in fetch executed with proper headers'
+    );
+    return Promise.resolve({ 
+      ok: true,
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+      json: Promise.resolve({ more: 'mocks' }),
+    });
+  };
+  const doNext = (action) => {
+    t.pass('apiMiddleware with custom fetch executed next state');
+  };
+  const doGetState = () => {};
+  const nextHandler = apiMiddleware(mockFetch)({ getState: doGetState });
+  const actionHandler = nextHandler(doNext);
+
+  t.plan(8);
+  actionHandler(anAction);
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1663,7 +1663,7 @@ test('apiMiddleware must dispatch a failure FSA on an unsuccessful API call with
   actionHandler(anAction);
 });
 
-test('apiMiddleware must allow fetch to be passed in', t => {
+test('apiMiddleware must allow fetch to be passed in', (t) => {
   const anAction = {
     [CALL_API]: {
       endpoint: 'http://127.0.0.1/api/users/1',


### PR DESCRIPTION
This was done in the most API-preserving way possible. Another (breaking) approach would be to force the library user to initialize the apiMiddleware with the given fetch. I'd actually prefer that, but thought that preserving the existing API would be the most important priority right now.

Note also that this way of doing it is slightly leaky as passing in fetch essentially modifies a global-ish variable. The test is actually quite leaky, since any test after it will be executed with the mocked fetch.

This was the result of some rapid prototyping. I just want to see if the idea has merit, and get some guidance on the right direction before getting too far into either approach.
