### PR TITLE
Remove .npmignore, change devDependencies and publish only lib and src

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-coverage

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "2.0.0-beta.1",
   "description": "Redux middleware for calling an API.",
   "main": "lib/index.js",
+  "files": [
+    "lib",
+    "src"
+  ],
   "scripts": {
     "build": "babel src --out-dir lib",
     "clean": "rimraf lib coverage",
@@ -26,12 +30,12 @@
   },
   "license": "MIT",
   "dependencies": {
-    "babel-plugin-transform-runtime": "^6.5.2",
-    "babel-runtime": "^6.5.0",
     "isomorphic-fetch": "^2.1.1",
     "lodash.isplainobject": "^3.2.0"
   },
   "devDependencies": {
+    "babel-plugin-transform-runtime": "^6.5.2",
+    "babel-runtime": "^6.5.0",
     "babel-cli": "^6.5.1",
     "babel-eslint": "^4.1.8",
     "babel-istanbul": "^0.6.0",


### PR DESCRIPTION
Why npm package contains all files from the repository?
I think it should only contain /lib, package.json and README.md, everything else should be excluded in .npmignore. Potentially /src could also be included so dev can analyze non-transpiled version.

I removed .npmignore and specified files in npm package in package.json in under `files` property. Also I moved babel-runtime and preset into devDependencies.

This is just suggestion and if I'm wrong, I would like to know why.
Thanks.