### PR TITLE
ignore .babelrc on publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
+.babelrc
 coverage


### PR DESCRIPTION
According to https://github.com/loggur/react-redux-provide/issues/17:

> React Native's made the migration to Babel 6, which has the unfortunate side effect of finding .babelrc files in node_modules and attempting to use those configurations (see this issue for more details).
> 
> As a result, Babel 5 configs break RN builds, and the team's official fix is to ask module authors if they would consider adding .babelrc to .npmignore.
> 

See also https://github.com/facebook/react-native/issues/4062#issuecomment-179944792