### PR TITLE
Issue 75: Fetch cannot be mocked

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,4 +1,4 @@
-import fetch from 'isomorphic-fetch';
+import 'isomorphic-fetch';
 import isPlainObject from 'lodash.isplainobject';
 
 import CALL_API from './CALL_API';


### PR DESCRIPTION


Came here to report it and saw @cevou did it a few days ago (https://github.com/agraboso/redux-api-middleware/issues/75). So here is a very simple PR to fix this problem.

Stop importing fetch from isomorphic-fect to rely on the globally registered fetch function.