### PR TITLE
fix apiMiddleware must not return promise on actions without [CALL_API]

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -13,121 +13,123 @@ import { getJSON, normalizeTypeDescriptors, actionWith } from './util';
  * @access public
  */
 function apiMiddleware({ getState }) {
-  return (next) => async (action) => {
+  return (next) => (action) => {
     // Do not process actions without a [CALL_API] property
     if (!isRSAA(action)) {
       return next(action);
     }
 
-    // Try to dispatch an error request FSA for invalid RSAAs
-    const validationErrors = validateRSAA(action);
-    if (validationErrors.length) {
-      const callAPI = action[CALL_API];
-      if (callAPI.types && Array.isArray(callAPI.types)) {
-        let requestType = callAPI.types[0];
-        if (requestType && requestType.type) {
-          requestType = requestType.type;
+    return (async () => {
+      // Try to dispatch an error request FSA for invalid RSAAs
+      const validationErrors = validateRSAA(action);
+      if (validationErrors.length) {
+        const callAPI = action[CALL_API];
+        if (callAPI.types && Array.isArray(callAPI.types)) {
+          let requestType = callAPI.types[0];
+          if (requestType && requestType.type) {
+            requestType = requestType.type;
+          }
+          next({
+            type: requestType,
+            payload: new InvalidRSAA(validationErrors),
+            error: true
+          });
         }
-        next({
-          type: requestType,
-          payload: new InvalidRSAA(validationErrors),
-          error: true
-        });
-      }
-      return;
-    }
-
-    // Parse the validated RSAA action
-    const callAPI = action[CALL_API];
-    var { endpoint, headers } = callAPI;
-    const { method, body, credentials, bailout, types } = callAPI;
-    const [requestType, successType, failureType] = normalizeTypeDescriptors(types);
-
-    // Should we bail out?
-    try {
-      if ((typeof bailout === 'boolean' && bailout) ||
-          (typeof bailout === 'function' && bailout(getState()))) {
         return;
       }
-    } catch (e) {
-      return next(await actionWith(
-        {
-          ...requestType,
-          payload: new RequestError('[CALL_API].bailout function failed'),
-          error: true
-        },
-        [action, getState()]
-      ));
-    }
 
-    // Process [CALL_API].endpoint function
-    if (typeof endpoint === 'function') {
+      // Parse the validated RSAA action
+      const callAPI = action[CALL_API];
+      var { endpoint, headers } = callAPI;
+      const { method, body, credentials, bailout, types } = callAPI;
+      const [requestType, successType, failureType] = normalizeTypeDescriptors(types);
+
+      // Should we bail out?
       try {
-        endpoint = endpoint(getState());
+        if ((typeof bailout === 'boolean' && bailout) ||
+            (typeof bailout === 'function' && bailout(getState()))) {
+          return;
+        }
       } catch (e) {
         return next(await actionWith(
           {
             ...requestType,
-            payload: new RequestError('[CALL_API].endpoint function failed'),
+            payload: new RequestError('[CALL_API].bailout function failed'),
             error: true
           },
           [action, getState()]
         ));
       }
-    }
 
-    // Process [CALL_API].headers function
-    if (typeof headers === 'function') {
+      // Process [CALL_API].endpoint function
+      if (typeof endpoint === 'function') {
+        try {
+          endpoint = endpoint(getState());
+        } catch (e) {
+          return next(await actionWith(
+            {
+              ...requestType,
+              payload: new RequestError('[CALL_API].endpoint function failed'),
+              error: true
+            },
+            [action, getState()]
+          ));
+        }
+      }
+
+      // Process [CALL_API].headers function
+      if (typeof headers === 'function') {
+        try {
+          headers = headers(getState());
+        } catch (e) {
+          return next(await actionWith(
+            {
+              ...requestType,
+              payload: new RequestError('[CALL_API].headers function failed'),
+              error: true
+            },
+            [action, getState()]
+          ));
+        }
+      }
+
+      // We can now dispatch the request FSA
+      next(await actionWith(
+        requestType,
+        [action, getState()]
+      ));
+
       try {
-        headers = headers(getState());
-      } catch (e) {
+        // Make the API call
+        var res = await fetch(endpoint, { method, body, credentials, headers });
+      } catch(e) {
+        // The request was malformed, or there was a network error
         return next(await actionWith(
           {
             ...requestType,
-            payload: new RequestError('[CALL_API].headers function failed'),
+            payload: new RequestError(e.message),
             error: true
           },
           [action, getState()]
         ));
       }
-    }
 
-    // We can now dispatch the request FSA
-    next(await actionWith(
-      requestType,
-      [action, getState()]
-    ));
-
-    try {
-      // Make the API call
-      var res = await fetch(endpoint, { method, body, credentials, headers });
-    } catch(e) {
-      // The request was malformed, or there was a network error
-      return next(await actionWith(
-        {
-          ...requestType,
-          payload: new RequestError(e.message),
-          error: true
-        },
-        [action, getState()]
-      ));
-    }
-
-    // Process the server response
-    if (res.ok) {
-      return next(await actionWith(
-        successType,
-        [action, getState(), res]
-      ));
-    } else {
-      return next(await actionWith(
-        {
-          ...failureType,
-          error: true
-        },
-        [action, getState(), res]
-      ));
-    }
+      // Process the server response
+      if (res.ok) {
+        return next(await actionWith(
+          successType,
+          [action, getState(), res]
+        ));
+      } else {
+        return next(await actionWith(
+          {
+            ...failureType,
+            error: true
+          },
+          [action, getState(), res]
+        ));
+      }
+    })()
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -855,6 +855,18 @@ test('apiMiddleware must pass actions without a [CALL_API] property to the next 
   actionHandler(anAction);
 });
 
+test('apiMiddleware mustn\'t return a promise on actions without a [CALL_API] property ', (t) => {
+  const anAction = {};
+  const doGetState = () => {};
+  const nextHandler = apiMiddleware({ getState: doGetState });
+  const doNext = (action) => action;
+  const actionHandler = nextHandler(doNext);
+
+  t.plan(1);
+  const noProm = actionHandler(anAction);
+  t.notEqual(typeof noProm.then, 'function', 'no promise returned');
+});
+
 test('apiMiddleware must dispatch an error request FSA for an invalid RSAA with a string request type', (t) => {
   const anAction = {
     [CALL_API]: {


### PR DESCRIPTION
**Problem:** 
`apiMiddleware` returns a promise for actions without a `[CALL_API]` property, this can lead to unexpected behaviour and nested promises.

**Solution:** 
Remove `async` from returned `action` function and return instead an async function after `isRSAA` validation.
