### PR TITLE
use fetch-everywhere to support all environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-runtime": "^5.8.25",
-    "isomorphic-fetch": "^2.1.1",
+    "fetch-everywhere": "^1.0.2",
     "lodash.isplainobject": "^3.2.0"
   },
   "devDependencies": {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,4 +1,4 @@
-import fetch from 'isomorphic-fetch';
+import fetch from 'fetch-everywhere';
 import isPlainObject from 'lodash.isplainobject';
 
 import CALL_API from './CALL_API';


### PR DESCRIPTION
`redux-api-middleware` currently doesn't work with `react-native` and throws an error because `self` is not defined as global variable in `react-native` environment. The author of `isomorphic-fetch` doesn't want to support `react-native` and this PR uses `fetch-everywhere` instead to support also all node environments.

`fetch-everywhere` is basically a fork of `isomorphic-fetch` with some adjustments.