### PR TITLE
Handle sync requests without await

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -93,10 +93,14 @@ function apiMiddleware({ getState }) {
     }
 
     // We can now dispatch the request FSA
-    next(await actionWith(
-      requestType,
-      [action, getState()]
-    ));
+    if(typeof requestType.payload === 'function' || typeof requestType.meta === 'function') {
+      next(await actionWith(
+        requestType,
+        [action, getState()]
+      ));
+    } else {
+      next(requestType);
+    }
 
     try {
       // Make the API call


### PR DESCRIPTION
It is a common pattern that after dispatching a request, we set an `isFetching` flag in the reducer. This flag is used in the bailout function to prevent sending the same request before receiving a reply from the server.

With the current implementation, `payload` and `meta` attributes can be promises / async functions that construct the attributes. This means that the `REQUEST` action has to wait for these to return before dispatching. During this time, other API call actions might be dispatched, and these would check for the bailout flag before any`REQUEST` is fired and before the bailout flag is set in the state. This results in multiple calls at the same time and make the bailout function not very useful.

This fix dispatches `REQUEST` actions with non-async `payload` and `meta` attributes synchronously, guaranteeing that the flag is set in the reducer before any other action is dispatched.
