### PR TITLE
Adds options parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,25 @@ It is usually an object, with the keys specifying the header names and the value
 
 It may also be a function taking the state of your Redux store as its argument, and returning an object of headers as above.
 
+#### `[CALL_API].options`
+
+The fetch options for the API call. See [node-fetch](https://github.com/bitinn/node-fetch#options) for more information.
+
+It is usually an object with the options keys/values. For example, you can specify a network timeout for node.js code
+in the following way.
+
+```js
+{
+  [CALL_API]: {
+    ...
+    options: { timeout: 3000 }
+    ...
+  }
+}
+```
+
+It may also be a function taking the state of your Redux store as its argument, and returning an object of options as above.
+
 #### `[CALL_API].credentials`
 
 Whether or not to send cookies with the API call.

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ It must be one of the strings `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE` or
 
 The body of the API call.
 
-`redux-api-middleware` uses [`isomorphic-fetch`](https://github.com/matthew-andrews/isomorphic-fetch) to make the API call. `[CALL_API].body` should hence be a valid body according to the the [fetch specification](https://fetch.spec.whatwg.org). In most cases, this will be a JSON-encoded string or a [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData) object.
+`redux-api-middleware` uses [`isomorphic-fetch`](https://github.com/matthew-andrews/isomorphic-fetch) to make the API call. `[CALL_API].body` should hence be a valid body according to the [fetch specification](https://fetch.spec.whatwg.org). In most cases, this will be a JSON-encoded string or a [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData) object.
 
 #### `[CALL_API].headers`
 
@@ -552,7 +552,7 @@ The `[CALL_API]` property MAY
 
 - have a `body` property,
 - have a `headers` property,
-- have a `options` property,
+- have an `options` property,
 - have a `credentials` property,
 - have a `bailout` property.
 
@@ -570,7 +570,7 @@ The `[CALL_API].method` property MUST be one of the strings `GET`, `HEAD`, `POST
 
 #### `[CALL_API].body`
 
-The optional `[CALL_API].body` property SHOULD be a valid body according to the the [fetch specification](https://fetch.spec.whatwg.org).
+The optional `[CALL_API].body` property SHOULD be a valid body according to the [fetch specification](https://fetch.spec.whatwg.org).
 
 #### `[CALL_API].headers`
 

--- a/README.md
+++ b/README.md
@@ -533,12 +533,13 @@ The `[CALL_API]` property MAY
 
 - have a `body` property,
 - have a `headers` property,
+- have a `options` property,
 - have a `credentials` property,
 - have a `bailout` property.
 
 The `[CALL_API]` property MUST NOT
 
-- include properties other than `endpoint`, `method`, `types`, `body`, `headers`, `credentials`, and `bailout`.
+- include properties other than `endpoint`, `method`, `types`, `body`, `headers`, `options`, `credentials`, and `bailout`.
 
 #### `[CALL_API].endpoint`
 
@@ -555,6 +556,11 @@ The optional `[CALL_API].body` property SHOULD be a valid body according to the 
 #### `[CALL_API].headers`
 
 The optional `[CALL_API].headers` property MUST be a plain JavaScript object or a function. In the second case, the function SHOULD return a plain JavaScript object.
+
+#### `[CALL_API].options`
+
+The optional `[CALL_API].options` property MUST be a plain JavaScript object or a function. In the second case, the function SHOULD return a plain JavaScript object.
+The options object can contain any options supported by [node-fetch](https://github.com/bitinn/node-fetch#options).
 
 #### `[CALL_API].credentials`
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -98,12 +98,12 @@ function apiMiddleware({ getState }) {
         options = options(getState());
       } catch (e) {
         return next(await actionWith(
-            {
-              ...requestType,
-              payload: new RequestError('[CALL_API].options function failed'),
-              error: true
-            },
-            [action, getState()]
+          {
+            ...requestType,
+            payload: new RequestError('[CALL_API].options function failed'),
+            error: true
+          },
+          [action, getState()]
         ));
       }
     }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -39,7 +39,7 @@ function apiMiddleware({ getState }) {
 
     // Parse the validated RSAA action
     const callAPI = action[CALL_API];
-    var { endpoint, headers } = callAPI;
+    var { endpoint, headers, options = {} } = callAPI;
     const { method, body, credentials, bailout, types } = callAPI;
     const [requestType, successType, failureType] = normalizeTypeDescriptors(types);
 
@@ -92,6 +92,22 @@ function apiMiddleware({ getState }) {
       }
     }
 
+    // Process [CALL_API].options function
+    if (typeof options === 'function') {
+      try {
+        options = options(getState());
+      } catch (e) {
+        return next(await actionWith(
+            {
+              ...requestType,
+              payload: new RequestError('[CALL_API].options function failed'),
+              error: true
+            },
+            [action, getState()]
+        ));
+      }
+    }
+
     // We can now dispatch the request FSA
     next(await actionWith(
       requestType,
@@ -100,7 +116,10 @@ function apiMiddleware({ getState }) {
 
     try {
       // Make the API call
-      var res = await fetch(endpoint, { method, body, credentials, headers });
+      var res = await fetch(endpoint, {
+        ...options,
+        method, body, credentials, headers
+      });
     } catch(e) {
       // The request was malformed, or there was a network error
       return next(await actionWith(

--- a/src/validation.js
+++ b/src/validation.js
@@ -58,6 +58,7 @@ function validateRSAA(action) {
   var validationErrors = [];
   const validCallAPIKeys = [
     'endpoint',
+    'options',
     'method',
     'body',
     'headers',
@@ -101,7 +102,7 @@ function validateRSAA(action) {
     }
   }
 
-  const { endpoint, method, headers, credentials, types, bailout } = callAPI;
+  const { endpoint, method, headers, options, credentials, types, bailout } = callAPI;
   if (typeof endpoint === 'undefined') {
     validationErrors.push('[CALL_API] must have an endpoint property');
   } else if (typeof endpoint !== 'string' && typeof endpoint !== 'function') {
@@ -117,6 +118,9 @@ function validateRSAA(action) {
 
   if (typeof headers !== 'undefined' && !isPlainObject(headers) && typeof headers !== 'function') {
     validationErrors.push('[CALL_API].headers property must be undefined, a plain JavaScript object, or a function');
+  }
+  if (typeof options !== 'undefined' && !isPlainObject(options) && typeof options !== 'function') {
+    validationErrors.push('[CALL_API].options property must be undefined, a plain JavaScript object, or a function');
   }
   if (typeof credentials !== 'undefined') {
     if (typeof credentials !== 'string') {


### PR DESCRIPTION
Adds options parameter to the CALL_API which is passed to the underlying fetch call. This allows us to control things like network timeouts and redirects, etc.

Example:

``` js
{
  [CALL_API]: {
    ...
    options: { timeout: 3000 }
    ...
  }
}
```

This is somewhat different than #79 that adds the possible options directly on the `CALL_API`.
