### PR TITLE
2.0 Beta: Alias RSAA to CALL_API, update docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ It must be one of the strings `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE` or
 
 The body of the API call.
 
-`redux-api-middleware` uses [`isomorphic-fetch`](https://github.com/matthew-andrews/isomorphic-fetch) to make the API call. `[RSAA].body` should hence be a valid body according to the the [fetch specification](https://fetch.spec.whatwg.org). In most cases, this will be a JSON-encoded string or a [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData) object.
+`redux-api-middleware` uses the [`Fetch API`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to make the API call. `[RSAA].body` should hence be a valid body according to the the [fetch specification](https://fetch.spec.whatwg.org). In most cases, this will be a JSON-encoded string or a [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData) object.
 
 #### `[RSAA].headers`
 
@@ -200,7 +200,7 @@ The `[RSAA].types` property controls the output of `redux-api-middleware`. The s
 
   But errors may pop up at this stage, for several reasons:
   - `redux-api-middleware` has to call those of `[RSAA].bailout`, `[RSAA].endpoint` and `[RSAA].headers` that happen to be a function, which may throw an error;
-  - `isomorphic-fetch` may throw an error: the RSAA definition is not strong enough to preclude that from happening (you may, for example, send in a `[RSAA].body` that is not valid according to the fetch specification &mdash; mind the SHOULDs in the [RSAA definition](#redux-standard-api-calling-actions));
+  - `fetch` may throw an error: the RSAA definition is not strong enough to preclude that from happening (you may, for example, send in a `[RSAA].body` that is not valid according to the fetch specification &mdash; mind the SHOULDs in the [RSAA definition](#redux-standard-api-calling-actions));
   - a network failure occurs (the network is unreachable, the server responds with an error,...).
 
   If such an error occurs, a different *request* FSA will be dispatched (*instead* of the one described above). It will contain the following properties:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@ redux-api-middleware
 ====================
 
 ## This `next` branch is 2.0.0-beta in development!
-Things are in a fluid state and we cannot make guarantees that this will work properly. This `README` might not be completely up-to-date &mdash; in fact, we have just removed `isomorphic-fetch` in favor of a global `fetch` (except in test), so please polyfill it.
+
+See [Upgrading from v1.0.x](#upgrading-from-v1.0.x) for details on upgrading, and issues for the [2.0 milestone here](https://github.com/agraboso/redux-api-middleware/issues?utf8=%E2%9C%93&q=milestone%3A2.0.0%20)
 
 [![Build Status](https://travis-ci.org/agraboso/redux-api-middleware.svg?branch=next)](https://travis-ci.org/agraboso/redux-api-middleware) [![Coverage Status](https://coveralls.io/repos/agraboso/redux-api-middleware/badge.svg?branch=next&service=github)](https://coveralls.io/github/agraboso/redux-api-middleware?branch=next)
 
@@ -24,8 +25,9 @@ Things are in a fluid state and we cannot make guarantees that this will work pr
   - [Redux Standard API-calling Actions](#redux-standard-api-calling-actions)
 5. [History](#history)
 6. [Tests](#tests)
-7. [License](License)
-8. [Acknowledgements](#acknowledgements)
+7. [Upgrading from v1.0.x](#upgrading-from-v1.0.x)
+8. [License](License)
+9. [Acknowledgements](#acknowledgements)
 
 ## Introduction
 
@@ -96,6 +98,8 @@ $ npm install redux-api-middleware --save
 ```
 
 To use it, wrap the standard Redux store with it. Here is an example setup. For more information (for example, on how to add several middlewares), consult the [Redux documentation](http://redux.js.org).
+
+Note: `redux-api-middleware` depends on a [global Fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) being available, and may require a polyfill for your runtime environment(s).
 
 #### configureStore.js
 
@@ -599,7 +603,9 @@ $ npm install && npm test
 
 ## Upgrading from v1.0.x
 
-TODO
+- The `CALL_API` symbol is replaced with the `RSAA` string as the top-level RSAA action key. `CALL_API` is aliased to the new value as of 2.0, but this will ultimately be deprecated.
+- `redux-api-middleware` no longer brings its own `fetch` implementation and depends on a global `fetch` to be provided in the runtime
+- A new `options` config is added to pass your `fetch` implementation extra options other than `method`, `headers`, `body` and `credentials`
 
 ## License
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@
  * @requires isomorphic-fetch
  * @requires lodash.isplainobject
  * @exports {string} RSAA
+ * @exports {string} CALL_API - alias of RSAA, to be deprecated in v3
  * @exports {function} isRSAA
  * @exports {function} validateRSAA
  * @exports {function} isValidRSAA
@@ -36,6 +37,10 @@ import { getJSON } from './util';
 import { apiMiddleware } from './middleware';
 
 export {
+  // Alias RSAA to CALL_API to smooth v1 - v2 migration
+  // TODO: Deprecate in v3
+  RSAA as CALL_API,
+
   RSAA,
   isRSAA,
   validateRSAA,


### PR DESCRIPTION
- 2.0 beta docs updates
- Alias `CALL_API` export to new `RSAA` string
- Adds test case for bad JSON response payload in #90