### PR TITLE
Default headers to empty hash, fixes bug in safari 10.1 and issue #144

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -106,7 +106,12 @@ function apiMiddleware({ getState }) {
 
     try {
       // Make the API call
-      var res = await fetch(endpoint, { method, body, credentials, headers });
+      var res = await fetch(endpoint, {
+        method,
+        body,
+        credentials,
+        headers: headers || {}
+      });
     } catch (e) {
       // The request was malformed, or there was a network error
       return next(


### PR DESCRIPTION
Re-implements https://github.com/agraboso/redux-api-middleware/pull/123 on `next`

Closes #144 