### PR TITLE
next: Adds options parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 *.log
 lib
 coverage
+.idea

--- a/README.md
+++ b/README.md
@@ -164,7 +164,30 @@ It is usually an object, with the keys specifying the header names and the value
 
 It may also be a function taking the state of your Redux store as its argument, and returning an object of headers as above.
 
+<<<<<<< HEAD
 #### `[RSAA].credentials`
+=======
+#### `[CALL_API].options`
+
+The fetch options for the API call. See [node-fetch](https://github.com/bitinn/node-fetch#options) for more information.
+
+It is usually an object with the options keys/values. For example, you can specify a network timeout for node.js code
+in the following way.
+
+```js
+{
+  [CALL_API]: {
+    ...
+    options: { timeout: 3000 }
+    ...
+  }
+}
+```
+
+It may also be a function taking the state of your Redux store as its argument, and returning an object of options as above.
+
+#### `[CALL_API].credentials`
+>>>>>>> Adds options parameter documentation and examples
 
 Whether or not to send cookies with the API call.
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ It may also be a function taking the state of your Redux store as its argument, 
 
 #### `[RSAA].options`
 
-The fetch options for the API call. See [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) for more information.
+The fetch options for the API call. What options are available depends on what fetch implementation is in use. See [MDN fetch](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) or [node-fetch](https://github.com/bitinn/node-fetch#options) for more information.
 
 It is usually an object with the options keys/values. For example, you can specify a network timeout for node.js code
 in the following way.
@@ -586,7 +586,8 @@ The optional `[RSAA].headers` property MUST be a plain JavaScript object or a fu
 #### `[RSAA].options`
 
 The optional `[RSAA].options` property MUST be a plain JavaScript object or a function. In the second case, the function SHOULD return a plain JavaScript object.
-The options object can contain any options supported by the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
+The options object can contain any options supported by the effective fetch implementation.
+See [MDN fetch](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch) or [node-fetch](https://github.com/bitinn/node-fetch#options).
 
 #### `[RSAA].credentials`
 

--- a/README.md
+++ b/README.md
@@ -540,12 +540,13 @@ The `[RSAA]` property MAY
 
 - have a `body` property,
 - have a `headers` property,
+- have a `options` property,
 - have a `credentials` property,
 - have a `bailout` property.
 
 The `[RSAA]` property MUST NOT
 
-- include properties other than `endpoint`, `method`, `types`, `body`, `headers`, `credentials`, and `bailout`.
+- include properties other than `endpoint`, `method`, `types`, `body`, `headers`, `options`, `credentials`, and `bailout`.
 
 #### `[RSAA].endpoint`
 
@@ -563,7 +564,13 @@ The optional `[RSAA].body` property SHOULD be a valid body according to the the 
 
 The optional `[RSAA].headers` property MUST be a plain JavaScript object or a function. In the second case, the function SHOULD return a plain JavaScript object.
 
+#### `[RSAA].options`
+
+The optional `[RSAA].options` property MUST be a plain JavaScript object or a function. In the second case, the function SHOULD return a plain JavaScript object.
+The options object can contain any options supported by [node-fetch](https://github.com/bitinn/node-fetch#options).
+
 #### `[RSAA].credentials`
+>>>>>>> Adds the options parameter to the documentation
 
 The optional `[RSAA].credentials` property MUST be one of the strings `omit`, `same-origin` or `include`.
 

--- a/README.md
+++ b/README.md
@@ -164,10 +164,7 @@ It is usually an object, with the keys specifying the header names and the value
 
 It may also be a function taking the state of your Redux store as its argument, and returning an object of headers as above.
 
-<<<<<<< HEAD
-#### `[RSAA].credentials`
-=======
-#### `[CALL_API].options`
+#### `[RSAA].options`
 
 The fetch options for the API call. See [node-fetch](https://github.com/bitinn/node-fetch#options) for more information.
 
@@ -176,7 +173,7 @@ in the following way.
 
 ```js
 {
-  [CALL_API]: {
+  [RSAA]: {
     ...
     options: { timeout: 3000 }
     ...
@@ -186,8 +183,7 @@ in the following way.
 
 It may also be a function taking the state of your Redux store as its argument, and returning an object of options as above.
 
-#### `[CALL_API].credentials`
->>>>>>> Adds options parameter documentation and examples
+#### `[RSAA].credentials`
 
 Whether or not to send cookies with the API call.
 
@@ -563,7 +559,7 @@ The `[RSAA]` property MAY
 
 - have a `body` property,
 - have a `headers` property,
-- have a `options` property,
+- have an `options` property,
 - have a `credentials` property,
 - have a `bailout` property.
 
@@ -581,7 +577,7 @@ The `[RSAA].method` property MUST be one of the strings `GET`, `HEAD`, `POST`, `
 
 #### `[RSAA].body`
 
-The optional `[RSAA].body` property SHOULD be a valid body according to the the [fetch specification](https://fetch.spec.whatwg.org).
+The optional `[RSAA].body` property SHOULD be a valid body according to the [fetch specification](https://fetch.spec.whatwg.org).
 
 #### `[RSAA].headers`
 
@@ -593,7 +589,6 @@ The optional `[RSAA].options` property MUST be a plain JavaScript object or a fu
 The options object can contain any options supported by [node-fetch](https://github.com/bitinn/node-fetch#options).
 
 #### `[RSAA].credentials`
->>>>>>> Adds the options parameter to the documentation
 
 The optional `[RSAA].credentials` property MUST be one of the strings `omit`, `same-origin` or `include`.
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ It must be one of the strings `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE` or
 
 The body of the API call.
 
-`redux-api-middleware` uses the [`Fetch API`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to make the API call. `[RSAA].body` should hence be a valid body according to the the [fetch specification](https://fetch.spec.whatwg.org). In most cases, this will be a JSON-encoded string or a [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData) object.
+`redux-api-middleware` uses the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to make the API call. `[RSAA].body` should hence be a valid body according to the [fetch specification](https://fetch.spec.whatwg.org). In most cases, this will be a JSON-encoded string or a [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData) object.
 
 #### `[RSAA].headers`
 
@@ -166,7 +166,7 @@ It may also be a function taking the state of your Redux store as its argument, 
 
 #### `[RSAA].options`
 
-The fetch options for the API call. See [node-fetch](https://github.com/bitinn/node-fetch#options) for more information.
+The fetch options for the API call. See [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) for more information.
 
 It is usually an object with the options keys/values. For example, you can specify a network timeout for node.js code
 in the following way.
@@ -586,7 +586,7 @@ The optional `[RSAA].headers` property MUST be a plain JavaScript object or a fu
 #### `[RSAA].options`
 
 The optional `[RSAA].options` property MUST be a plain JavaScript object or a function. In the second case, the function SHOULD return a plain JavaScript object.
-The options object can contain any options supported by [node-fetch](https://github.com/bitinn/node-fetch#options).
+The options object can contain any options supported by the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
 
 #### `[RSAA].credentials`
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 /**
  * Redux middleware for calling an API
  * @module redux-api-middleware
- * @requires isomorphic-fetch
  * @requires lodash.isplainobject
  * @exports {string} RSAA
  * @exports {string} CALL_API - alias of RSAA, to be deprecated in v3

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -102,7 +102,7 @@ function apiMiddleware({ getState }) {
             payload: new RequestError('[CALL_API].options function failed'),
             error: true
           },
-            [action, getState()]
+          [action, getState()]
         ));
       }
     }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -91,7 +91,7 @@ function apiMiddleware({ getState }) {
       }
     }
 
-    // Process [CALL_API].options function
+    // Process [RSAA].options function
     if (typeof options === 'function') {
       try {
         options = options(getState());
@@ -99,7 +99,7 @@ function apiMiddleware({ getState }) {
         return next(await actionWith(
           {
             ...requestType,
-            payload: new RequestError('[CALL_API].options function failed'),
+            payload: new RequestError('[RSAA].options function failed'),
             error: true
           },
           [action, getState()]

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,9 +1,7 @@
-import isPlainObject from 'lodash.isplainobject';
-
 import RSAA from './RSAA';
 import { isRSAA, validateRSAA } from './validation';
-import { InvalidRSAA, RequestError, ApiError } from './errors';
-import { getJSON, normalizeTypeDescriptors, actionWith } from './util';
+import { InvalidRSAA, RequestError } from './errors';
+import { normalizeTypeDescriptors, actionWith } from './util';
 
 /**
  * A Redux middleware that processes RSAA actions.

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -104,14 +104,16 @@ function apiMiddleware({ getState }) {
       try {
         options = options(getState());
       } catch (e) {
-        return next(await actionWith(
-          {
-            ...requestType,
-            payload: new RequestError('[RSAA].options function failed'),
-            error: true
-          },
-          [action, getState()]
-        ));
+        return next(
+          await actionWith(
+            {
+              ...requestType,
+              payload: new RequestError('[RSAA].options function failed'),
+              error: true
+            },
+            [action, getState()]
+          )
+        );
       }
     }
 
@@ -120,8 +122,14 @@ function apiMiddleware({ getState }) {
 
     try {
       // Make the API call
-      var res = await fetch(endpoint, {...options, method, body, credentials, headers: headers || {} });
-    } catch(e) {
+      var res = await fetch(endpoint, {
+        ...options,
+        method,
+        body,
+        credentials,
+        headers: headers || {}
+      });
+    } catch (e) {
       // The request was malformed, or there was a network error
       return next(
         await actionWith(

--- a/src/validation.js
+++ b/src/validation.js
@@ -120,7 +120,7 @@ function validateRSAA(action) {
     validationErrors.push('[RSAA].headers property must be undefined, a plain JavaScript object, or a function');
   }
   if (typeof options !== 'undefined' && !isPlainObject(options) && typeof options !== 'function') {
-    validationErrors.push('[CALL_API].options property must be undefined, a plain JavaScript object, or a function');
+    validationErrors.push('[RSAA].options property must be undefined, a plain JavaScript object, or a function');
   }
   if (typeof credentials !== 'undefined') {
     if (typeof credentials !== 'string') {

--- a/src/validation.js
+++ b/src/validation.js
@@ -58,6 +58,7 @@ function validateRSAA(action) {
   var validationErrors = [];
   const validCallAPIKeys = [
     'endpoint',
+    'options',
     'method',
     'body',
     'headers',
@@ -101,7 +102,7 @@ function validateRSAA(action) {
     }
   }
 
-  const { endpoint, method, headers, credentials, types, bailout } = callAPI;
+  const { endpoint, method, headers, options, credentials, types, bailout } = callAPI;
   if (typeof endpoint === 'undefined') {
     validationErrors.push('[RSAA] must have an endpoint property');
   } else if (typeof endpoint !== 'string' && typeof endpoint !== 'function') {
@@ -117,6 +118,9 @@ function validateRSAA(action) {
 
   if (typeof headers !== 'undefined' && !isPlainObject(headers) && typeof headers !== 'function') {
     validationErrors.push('[RSAA].headers property must be undefined, a plain JavaScript object, or a function');
+  }
+  if (typeof options !== 'undefined' && !isPlainObject(options) && typeof options !== 'function') {
+    validationErrors.push('[CALL_API].options property must be undefined, a plain JavaScript object, or a function');
   }
   if (typeof credentials !== 'undefined') {
     if (typeof credentials !== 'string') {

--- a/src/validation.js
+++ b/src/validation.js
@@ -96,7 +96,15 @@ function validateRSAA(action) {
     }
   }
 
-  const { endpoint, method, headers, options, credentials, types, bailout } = callAPI;
+  const {
+    endpoint,
+    method,
+    headers,
+    options,
+    credentials,
+    types,
+    bailout
+  } = callAPI;
   if (typeof endpoint === 'undefined') {
     validationErrors.push('[RSAA] must have an endpoint property');
   } else if (typeof endpoint !== 'string' && typeof endpoint !== 'function') {
@@ -121,8 +129,14 @@ function validateRSAA(action) {
       '[RSAA].headers property must be undefined, a plain JavaScript object, or a function'
     );
   }
-  if (typeof options !== 'undefined' && !isPlainObject(options) && typeof options !== 'function') {
-    validationErrors.push('[RSAA].options property must be undefined, a plain JavaScript object, or a function');
+  if (
+    typeof options !== 'undefined' &&
+    !isPlainObject(options) &&
+    typeof options !== 'function'
+  ) {
+    validationErrors.push(
+      '[RSAA].options property must be undefined, a plain JavaScript object, or a function'
+    );
   }
   if (typeof credentials !== 'undefined') {
     if (typeof credentials !== 'string') {

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,5 @@
 import test from 'tape';
-import fetch from 'isomorphic-fetch';
-import { Schema, normalize, arrayOf } from 'normalizr';
+import 'isomorphic-fetch';
 import nock from 'nock';
 
 // Public package exports

--- a/test/index.js
+++ b/test/index.js
@@ -488,12 +488,14 @@ test('validateRSAA/isValidRSAA must identify conformant RSAAs', t => {
     }
   };
   t.ok(
-      validateRSAA(action24).includes('[RSAA].options property must be undefined, a plain JavaScript object, or a function'),
-      '[RSAA].options property must be undefined, a plain JavaScript object, or a function (validateRSAA)'
+    validateRSAA(action24).includes(
+      '[RSAA].options property must be undefined, a plain JavaScript object, or a function'
+    ),
+    '[RSAA].options property must be undefined, a plain JavaScript object, or a function (validateRSAA)'
   );
   t.notOk(
-      isValidRSAA(action24),
-      '[RSAA].options property must be undefined, a plain JavaScript object, or a function (isValidRSAA)'
+    isValidRSAA(action24),
+    '[RSAA].options property must be undefined, a plain JavaScript object, or a function (isValidRSAA)'
   );
 
   const action25 = {
@@ -505,13 +507,13 @@ test('validateRSAA/isValidRSAA must identify conformant RSAAs', t => {
     }
   };
   t.equal(
-      validateRSAA(action25).length,
-      0,
-      '[RSAA].options may be a plain JavaScript object (validateRSAA)'
+    validateRSAA(action25).length,
+    0,
+    '[RSAA].options may be a plain JavaScript object (validateRSAA)'
   );
   t.ok(
-      isValidRSAA(action25),
-      '[RSAA].options may be a plain JavaScript object (isRSAA)'
+    isValidRSAA(action25),
+    '[RSAA].options may be a plain JavaScript object (isRSAA)'
   );
 
   const action26 = {
@@ -523,14 +525,11 @@ test('validateRSAA/isValidRSAA must identify conformant RSAAs', t => {
     }
   };
   t.equal(
-      validateRSAA(action26).length,
-      0,
-      '[RSAA].options may be a function (validateRSAA)'
+    validateRSAA(action26).length,
+    0,
+    '[RSAA].options may be a function (validateRSAA)'
   );
-  t.ok(
-      isValidRSAA(action26),
-      '[RSAA].options may be a function (isRSAA)'
-  );
+  t.ok(isValidRSAA(action26), '[RSAA].options may be a function (isRSAA)');
 
   t.end();
 });
@@ -1161,7 +1160,9 @@ test('apiMiddleware must use an [RSAA].bailout function when present', t => {
 });
 
 test('apiMiddleware must use an [RSAA].endpoint function when present', t => {
-  const api = nock('http://127.0.0.1').get('/api/users/1').reply(200);
+  const api = nock('http://127.0.0.1')
+    .get('/api/users/1')
+    .reply(200);
   const anAction = {
     [RSAA]: {
       endpoint: () => {
@@ -1182,7 +1183,9 @@ test('apiMiddleware must use an [RSAA].endpoint function when present', t => {
 });
 
 test('apiMiddleware must use an [RSAA].headers function when present', t => {
-  const api = nock('http://127.0.0.1').get('/api/users/1').reply(200);
+  const api = nock('http://127.0.0.1')
+    .get('/api/users/1')
+    .reply(200);
   const anAction = {
     [RSAA]: {
       endpoint: 'http://127.0.0.1/api/users/1',
@@ -1202,23 +1205,23 @@ test('apiMiddleware must use an [RSAA].headers function when present', t => {
   actionHandler(anAction);
 });
 
-test('apiMiddleware must use an [RSAA].options function when present', (t) => {
+test('apiMiddleware must use an [RSAA].options function when present', t => {
   const api = nock('http://127.0.0.1')
-      .get('/api/users/1')
-      .reply(200);
+    .get('/api/users/1')
+    .reply(200);
   const anAction = {
     [RSAA]: {
       endpoint: 'http://127.0.0.1/api/users/1',
       method: 'GET',
       options: () => {
-        t.pass('[RSAA].options function called')
+        t.pass('[RSAA].options function called');
       },
       types: ['REQUEST', 'SUCCESS', 'FAILURE']
     }
   };
   const doGetState = () => {};
   const nextHandler = apiMiddleware({ getState: doGetState });
-  const doNext = (action) => {};
+  const doNext = action => {};
   const actionHandler = nextHandler(doNext);
 
   t.plan(1);
@@ -1418,7 +1421,9 @@ test('apiMiddleware must dispatch a success FSA with an error state on a success
 });
 
 test('apiMiddleware must dispatch a success FSA on a successful API call with a non-JSON response', t => {
-  const api = nock('http://127.0.0.1').get('/api/users/1').reply(200);
+  const api = nock('http://127.0.0.1')
+    .get('/api/users/1')
+    .reply(200);
   const anAction = {
     [RSAA]: {
       endpoint: 'http://127.0.0.1/api/users/1',
@@ -1606,7 +1611,9 @@ test('apiMiddleware must dispatch a failure FSA on an unsuccessful API call with
 });
 
 test('apiMiddleware must dispatch a failure FSA on an unsuccessful API call with a non-JSON response', t => {
-  const api = nock('http://127.0.0.1').get('/api/users/1').reply(404);
+  const api = nock('http://127.0.0.1')
+    .get('/api/users/1')
+    .reply(404);
   const anAction = {
     [RSAA]: {
       endpoint: 'http://127.0.0.1/api/users/1',

--- a/test/index.js
+++ b/test/index.js
@@ -1043,6 +1043,48 @@ test('apiMiddleware must dispatch an error request FSA when [RSAA].headers fails
   actionHandler(anAction);
 });
 
+test('apiMiddleware must dispatch an error request FSA when [RSAA].options fails', t => {
+    const anAction = {
+        [RSAA]: {
+            endpoint: '',
+            method: 'GET',
+            options: () => {
+                throw new Error();
+            },
+            types: [
+                {
+                    type: 'REQUEST',
+                    payload: 'ignoredPayload',
+                    meta: 'someMeta'
+                },
+                'SUCCESS',
+                'FAILURE'
+            ]
+        }
+    };
+    const doGetState = () => {};
+    const nextHandler = apiMiddleware({ getState: doGetState });
+    const doNext = action => {
+        t.pass('next handler called');
+        t.equal(action.type, 'REQUEST', 'dispatched FSA has correct type property');
+        t.equal(
+            action.payload.message,
+            '[RSAA].options function failed',
+            'dispatched FSA has correct payload property'
+        );
+        t.equal(
+            action.meta,
+            'someMeta',
+            'dispatched FSA has correct meta property'
+        );
+        t.ok(action.error, 'dispatched FSA has correct error property');
+    };
+    const actionHandler = nextHandler(doNext);
+
+    t.plan(5);
+    actionHandler(anAction);
+});
+
 test('apiMiddleware must dispatch an error request FSA on a request error', t => {
   const anAction = {
     [RSAA]: {

--- a/test/index.js
+++ b/test/index.js
@@ -1044,45 +1044,45 @@ test('apiMiddleware must dispatch an error request FSA when [RSAA].headers fails
 });
 
 test('apiMiddleware must dispatch an error request FSA when [RSAA].options fails', t => {
-    const anAction = {
-        [RSAA]: {
-            endpoint: '',
-            method: 'GET',
-            options: () => {
-                throw new Error();
-            },
-            types: [
-                {
-                    type: 'REQUEST',
-                    payload: 'ignoredPayload',
-                    meta: 'someMeta'
-                },
-                'SUCCESS',
-                'FAILURE'
-            ]
-        }
-    };
-    const doGetState = () => {};
-    const nextHandler = apiMiddleware({ getState: doGetState });
-    const doNext = action => {
-        t.pass('next handler called');
-        t.equal(action.type, 'REQUEST', 'dispatched FSA has correct type property');
-        t.equal(
-            action.payload.message,
-            '[RSAA].options function failed',
-            'dispatched FSA has correct payload property'
-        );
-        t.equal(
-            action.meta,
-            'someMeta',
-            'dispatched FSA has correct meta property'
-        );
-        t.ok(action.error, 'dispatched FSA has correct error property');
-    };
-    const actionHandler = nextHandler(doNext);
+  const anAction = {
+    [RSAA]: {
+      endpoint: '',
+      method: 'GET',
+      options: () => {
+        throw new Error();
+      },
+      types: [
+        {
+          type: 'REQUEST',
+          payload: 'ignoredPayload',
+          meta: 'someMeta'
+        },
+        'SUCCESS',
+        'FAILURE'
+      ]
+    }
+  };
+  const doGetState = () => {};
+  const nextHandler = apiMiddleware({ getState: doGetState });
+  const doNext = action => {
+    t.pass('next handler called');
+    t.equal(action.type, 'REQUEST', 'dispatched FSA has correct type property');
+    t.equal(
+      action.payload.message,
+      '[RSAA].options function failed',
+      'dispatched FSA has correct payload property'
+    );
+    t.equal(
+      action.meta,
+      'someMeta',
+      'dispatched FSA has correct meta property'
+    );
+    t.ok(action.error, 'dispatched FSA has correct error property');
+  };
+  const actionHandler = nextHandler(doNext);
 
-    t.plan(5);
-    actionHandler(anAction);
+  t.plan(5);
+  actionHandler(anAction);
 });
 
 test('apiMiddleware must dispatch an error request FSA on a request error', t => {


### PR DESCRIPTION
Adds options parameter to the CALL_API which is passed to the underlying fetch call. This allows us to control things like network timeouts and redirects, etc.

Example:

``` js
{
  [CALL_API]: {
    ...
    options: { timeout: 3000 }
    ...
  }
}
```

This is somewhat different than #79 that adds the possible options directly on the `CALL_API`.

This replaces #101 that was the same thing but for `1.x`.