### PR TITLE
Dropped isomorphic-fetch in favor of cross-fetch (React Native compatible).

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ It must be one of the strings `GET`, `HEAD`, `POST`, `PUT`, `PATCH`, `DELETE` or
 
 The body of the API call.
 
-`redux-api-middleware` uses [`isomorphic-fetch`](https://github.com/matthew-andrews/isomorphic-fetch) to make the API call. `[CALL_API].body` should hence be a valid body according to the the [fetch specification](https://fetch.spec.whatwg.org). In most cases, this will be a JSON-encoded string or a [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData) object.
+`redux-api-middleware` uses [`cross-fetch`](https://github.com/lquixada/cross-fetch) to make the API call. `[CALL_API].body` should hence be a valid body according to the the [fetch specification](https://fetch.spec.whatwg.org). In most cases, this will be a JSON-encoded string or a [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData) object.
 
 #### `[CALL_API].headers`
 
@@ -193,7 +193,7 @@ The `[CALL_API].types` property controls the output of `redux-api-middleware`. T
 
   But errors may pop up at this stage, for several reasons:
   - `redux-api-middleware` has to call those of `[CALL_API].bailout`, `[CALL_API].endpoint` and `[CALL_API].headers` that happen to be a function, which may throw an error;
-  - `isomorphic-fetch` may throw an error: the RSAA definition is not strong enough to preclude that from happening (you may, for example, send in a `[CALL_API].body` that is not valid according to the fetch specification &mdash; mind the SHOULDs in the [RSAA definition](#redux-standard-api-calling-actions));
+  - `cross-fetch` may throw an error: the RSAA definition is not strong enough to preclude that from happening (you may, for example, send in a `[CALL_API].body` that is not valid according to the fetch specification &mdash; mind the SHOULDs in the [RSAA definition](#redux-standard-api-calling-actions));
   - a network failure occurs (the network is unreachable, the server responds with an error,...).
 
   If such an error occurs, a different *request* FSA will be dispatched (*instead* of the one described above). It will contain the following properties:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "babel-runtime": "^5.8.25",
-    "isomorphic-fetch": "^2.1.1",
+    "cross-fetch": "^1.1.0",
     "lodash.isplainobject": "^3.2.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /**
  * Redux middleware for calling an API
  * @module redux-api-middleware
- * @requires isomorphic-fetch
+ * @requires cross-fetch
  * @requires lodash.isplainobject
  * @exports {symbol} CALL_API
  * @exports {function} isRSAA

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,4 +1,4 @@
-import fetch from 'isomorphic-fetch';
+import fetch from 'cross-fetch';
 
 import CALL_API from './CALL_API';
 import { isRSAA, validateRSAA } from './validation';


### PR DESCRIPTION
isomorphic-fetch hasn't been updated for a while, so cross-fetch was created in order to provide a more updated, flexible and fixed alternative to the community.