### PR TITLE
Default fetch body option to undefined

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -133,7 +133,7 @@ function apiMiddleware({ getState }) {
         var res = await fetch(endpoint, {
           ...options,
           method,
-          body,
+          body: body || undefined,
           credentials,
           headers: headers || {}
         });


### PR DESCRIPTION
Addressing https://github.com/agraboso/redux-api-middleware/issues/138 by defaulting the `body` option passed to `fetch` to `undefined`

~~Adds `sinon` to the test harness, and a test case verifying fetch is not passed a body of `null`~~ punted on this, will be putting more thought into this type of testing in the near future