### PR TITLE
Allow [RSAA].body to be passed as a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ The body of the API call.
 
 `redux-api-middleware` uses the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to make the API call. `[RSAA].body` should hence be a valid body according to the [fetch specification](https://fetch.spec.whatwg.org). In most cases, this will be a JSON-encoded string or a [`FormData`](https://developer.mozilla.org/en/docs/Web/API/FormData) object.
 
+It may also be a function taking the state of your Redux store as its argument, and returning a body as described above.
+
 #### `[RSAA].headers`
 
 The HTTP headers for the API call.
@@ -218,7 +220,7 @@ The `[RSAA].types` property controls the output of `redux-api-middleware`. The s
   - `type`: the string constant in the first position of the `[RSAA].types` array.
 
   But errors may pop up at this stage, for several reasons:
-  - `redux-api-middleware` has to call those of `[RSAA].bailout`, `[RSAA].endpoint` and `[RSAA].headers` that happen to be a function, which may throw an error;
+  - `redux-api-middleware` has to call those of `[RSAA].bailout`, `[RSAA].endpoint`, `[RSAA].body`, `[RSAA].options` and `[RSAA].headers` that happen to be a function, which may throw an error;
   - `fetch` may throw an error: the RSAA definition is not strong enough to preclude that from happening (you may, for example, send in a `[RSAA].body` that is not valid according to the fetch specification &mdash; mind the SHOULDs in the [RSAA definition](#redux-standard-api-calling-actions));
   - a network failure occurs (the network is unreachable, the server responds with an error,...).
 
@@ -577,7 +579,7 @@ The `[RSAA].method` property MUST be one of the strings `GET`, `HEAD`, `POST`, `
 
 #### `[RSAA].body`
 
-The optional `[RSAA].body` property SHOULD be a valid body according to the [fetch specification](https://fetch.spec.whatwg.org).
+The optional `[RSAA].body` property SHOULD be a valid body according to the [fetch specification](https://fetch.spec.whatwg.org), or a function. In the second case, the function SHOULD return a valid body.
 
 #### `[RSAA].headers`
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -37,8 +37,8 @@ function apiMiddleware({ getState }) {
 
       // Parse the validated RSAA action
       const callAPI = action[RSAA];
-      var { endpoint, headers, options = {} } = callAPI;
-      const { method, body, credentials, bailout, types } = callAPI;
+      var { endpoint, body, headers, options = {} } = callAPI;
+      const { method, credentials, bailout, types } = callAPI;
       const [requestType, successType, failureType] = normalizeTypeDescriptors(
         types
       );
@@ -74,6 +74,24 @@ function apiMiddleware({ getState }) {
               {
                 ...requestType,
                 payload: new RequestError('[RSAA].endpoint function failed'),
+                error: true
+              },
+              [action, getState()]
+            )
+          );
+        }
+      }
+
+      // Process [RSAA].body function
+      if (typeof body === 'function') {
+        try {
+          body = body(getState());
+        } catch (e) {
+          return next(
+            await actionWith(
+              {
+                ...requestType,
+                payload: new RequestError('[RSAA].body function failed'),
                 error: true
               },
               [action, getState()]


### PR DESCRIPTION
This is #103, rebased and updated to be compatible with 2.x -- h/t @tungv 👏 👏 

Docs are also updated in this PR to reflect this new capability.