### PR TITLE
Add response handler

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,5 +1,6 @@
 const defaults = {
-  responseOk: res => res.ok
+  ok: res => res.ok,
+  fetch
 };
 
 export default defaults;

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,0 +1,5 @@
+const defaults = {
+  responseOk: res => res.ok
+};
+
+export default defaults;

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,6 @@ export {
   RequestError,
   ApiError,
   getJSON,
-  apiMiddleware,
-  createMiddleware
+  createMiddleware,
+  apiMiddleware
 };

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ import RSAA from './RSAA';
 import { isRSAA, validateRSAA, isValidRSAA } from './validation';
 import { InvalidRSAA, InternalError, RequestError, ApiError } from './errors';
 import { getJSON } from './util';
-import { apiMiddleware } from './middleware';
+import { apiMiddleware, createMiddleware } from './middleware';
 
 export {
   // Alias RSAA to CALL_API to smooth v1 - v2 migration
@@ -48,5 +48,6 @@ export {
   RequestError,
   ApiError,
   getJSON,
-  apiMiddleware
+  apiMiddleware,
+  createMiddleware
 };

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -39,7 +39,8 @@ function createMiddleware(options = {}) {
         body,
         headers,
         options = {},
-        fetch: doFetch = fetch
+        fetch: doFetch = middlewareOptions.fetch,
+        ok = middlewareOptions.ok
       } = callAPI;
       const { method, credentials, bailout, types } = callAPI;
       const [requestType, successType, failureType] = normalizeTypeDescriptors(
@@ -173,7 +174,7 @@ function createMiddleware(options = {}) {
       }
 
       // Process the server response
-      if (middlewareOptions.responseOk(res)) {
+      if (ok(res)) {
         return next(await actionWith(successType, [action, getState(), res]));
       } else {
         return next(

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -4,7 +4,7 @@ import { InvalidRSAA, RequestError } from './errors';
 import { normalizeTypeDescriptors, actionWith } from './util';
 import defaults from './defaults';
 
-export function createMiddleware(options = {}) {
+function createMiddleware(options = {}) {
   const middlewareOptions = Object.assign({}, defaults, options);
 
   return ({ getState }) => next => action => {
@@ -200,4 +200,4 @@ function apiMiddleware({ getState }) {
   return createMiddleware()({ getState });
 }
 
-export { apiMiddleware };
+export { createMiddleware, apiMiddleware };

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -200,7 +200,7 @@ export function createMiddleware(options = {}) {
  * @access public
  */
 function apiMiddleware({ getState }) {
-  return createMiddleware()(...arguments);
+  return createMiddleware()({ getState });
 }
 
 export { apiMiddleware };

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -2,10 +2,7 @@ import RSAA from './RSAA';
 import { isRSAA, validateRSAA } from './validation';
 import { InvalidRSAA, RequestError } from './errors';
 import { normalizeTypeDescriptors, actionWith } from './util';
-
-const defaults = {
-  responseOk: res => res.ok
-};
+import defaults from './defaults';
 
 export function createMiddleware(options = {}) {
   const middlewareOptions = Object.assign({}, defaults, options);

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -3,14 +3,14 @@ import { isRSAA, validateRSAA } from './validation';
 import { InvalidRSAA, RequestError } from './errors';
 import { normalizeTypeDescriptors, actionWith } from './util';
 
-/**
- * A Redux middleware that processes RSAA actions.
- *
- * @type {ReduxMiddleware}
- * @access public
- */
-function apiMiddleware({ getState }) {
-  return next => action => {
+const defaults = {
+  responseOk: res => res.ok
+};
+
+export function createMiddleware(options = {}) {
+  const middlewareOptions = Object.assign({}, defaults, options);
+
+  return ({ getState }) => next => action => {
     // Do not process actions without an [RSAA] property
     if (!isRSAA(action)) {
       return next(action);
@@ -176,7 +176,7 @@ function apiMiddleware({ getState }) {
       }
 
       // Process the server response
-      if (res.ok) {
+      if (middlewareOptions.responseOk(res)) {
         return next(await actionWith(successType, [action, getState(), res]));
       } else {
         return next(
@@ -191,6 +191,16 @@ function apiMiddleware({ getState }) {
       }
     })();
   };
+}
+
+/**
+ * A Redux middleware that processes RSAA actions.
+ *
+ * @type {ReduxMiddleware}
+ * @access public
+ */
+function apiMiddleware({ getState }) {
+  return createMiddleware()(...arguments);
 }
 
 export { apiMiddleware };


### PR DESCRIPTION
Added a wrapper for apiMiddleware so user can pass his own check if response is OK

User can import as usual `apiMiddleware`
Or can import function `createMiddleware` that when called with options will return the `apiMiddleware`

TODO:
* [x] global response OK handler
* [x] ~global JSON response handler~
* [x] per-request response OK handler
* [x] ~per-request JSON response handler~
* [ ] Write tests
* [ ] Add JsDocs
* [ ] Update docs.

Closes #170 