### PR TITLE
allow non-Symbol object properties on RSAA

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,9 +813,9 @@ A *Redux Standard API-calling Action* MUST
 - be a plain JavaScript object,
 - have an `[RSAA]` property.
 
-A *Redux Standard API-calling Action* MUST NOT
+A *Redux Standard API-calling Action* MAY
 
-- include properties other than `[RSAA]`.
+- include properties other than `[RSAA]` (but will be ignored by redux-api-middleware).
 
 #### `[RSAA]`
 

--- a/src/validation.js
+++ b/src/validation.js
@@ -82,12 +82,6 @@ function validateRSAA(action) {
     return validationErrors;
   }
 
-  for (let key in action) {
-    if (key !== RSAA) {
-      validationErrors.push(`Invalid root key: ${key}`);
-    }
-  }
-
   const callAPI = action[RSAA];
   if (!isPlainObject(callAPI)) {
     validationErrors.push('[RSAA] property must be a plain JavaScript object');

--- a/test/index.js
+++ b/test/index.js
@@ -94,16 +94,17 @@ test('validateRSAA/isValidRSAA must identify conformant RSAAs', t => {
   );
 
   const action2 = {
-    [RSAA]: {},
-    invalidKey: ''
+    [RSAA]: {
+      endpoint: '',
+      method: 'GET',
+      types: ['REQUEST', 'SUCCESS', 'FAILURE']
+    },
+    anotherKey: 'foo'
   };
-  t.ok(
-    validateRSAA(action2).includes('Invalid root key: invalidKey'),
-    'RSAAs must not have properties other than [RSAA] (validateRSAA)'
-  );
-  t.notOk(
-    isValidRSAA(action2),
-    'RSAAs must not have properties other than [RSAA] (isValidRSAA)'
+  t.equal(
+    validateRSAA(action2).length,
+    0,
+    'RSAAs may have properties other than [RSAA] (validateRSAA)'
   );
 
   const action3 = {
@@ -563,6 +564,20 @@ test('validateRSAA/isValidRSAA must identify conformant RSAAs', t => {
   t.notOk(
     isValidRSAA(action29),
     '[RSAA].ok property must be a function (isRSAA)'
+  );
+
+  const action30 = {
+    [RSAA]: {
+      endpoint: '',
+      method: 'GET',
+      types: ['REQUEST', 'SUCCESS', 'FAILURE']
+    },
+    [Symbol('action30 Symbol')]: 'foo'
+  };
+  t.equal(
+    validateRSAA(action30).length,
+    0,
+    'RSAAs may have Symbol properties other than [RSAA] (validateRSAA)'
   );
 
   t.end();


### PR DESCRIPTION
Here's the proposed change regarding Issue #188.

Dev setup was easier than expected and worked just as described! 👍Let me know if I need to change anything for convention, or add/edit additional tests or documentation.

This change only removes this requirement from the `validateRSAA` method, and from the documentation.  It doesn't seem as if anything else in the codebase requires the old behavior.

This is still a breaking change though and does effect the existing RSAA specification, so probably best grouped into a future `major` (v3+) release after ppl have time to discuss in this PR (and if we still want to make this change) :)