### PR TITLE
Add custom `ok` hander (#171) + cleanup, docs, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ RSAAs are identified by the presence of an `[RSAA]` property, where [`RSAA`](#rs
   - [Exports](#exports)
     - [`RSAA`](#rsaa)
     - [`apiMiddleware`](#apimiddleware)
+    - [`createMiddleware(options)`](#createmiddlewareoptions)
     - [`isRSAA(action)`](#isrsaaaction)
     - [`validateRSAA(action)`](#validatersaaaction)
     - [`isValidRSAA(action)`](#isvalidrsaaaction)
@@ -64,6 +65,7 @@ RSAAs are identified by the presence of an `[RSAA]` property, where [`RSAA`](#rs
     - [`[RSAA].credentials`](#rsaacredentials-1)
     - [`[RSAA].bailout`](#rsaabailout)
     - [`[RSAA].fetch`](#rsaafetch-1)
+    - [`[RSAA].ok`](#rsaaok)
     - [`[RSAA].types`](#rsaatypes)
     - [Type descriptors](#type-descriptors)
 - [History](#history)
@@ -690,6 +692,15 @@ A JavaScript `String` whose presence as a key in an action signals that `redux-a
 
 The Redux middleware itself.
 
+#### `createMiddleware(options)`
+
+A function that creates an `apiMiddleware` with custom options.
+
+The following `options` properties are used:
+
+- `fetch` - provide a `fetch` API compatible function here to use instead of the default `window.fetch`
+- `ok` - provide a function here to use as a status check in the RSAA flow instead of `(res) => res.ok`
+
 #### `isRSAA(action)`
 
 A function that returns `true` if `action` has an `[RSAA]` property, and `false` otherwise.
@@ -860,7 +871,11 @@ The optional `[RSAA].bailout` property MUST be a boolean or a function.
 
 #### `[RSAA].fetch`
 
-The optional `[RSAA].fetch` property MUST be a function.
+The optional `[RSAA].fetch` property MUST be a function that conforms to the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
+
+#### `[RSAA].ok`
+
+The optional `[RSAA].ok` property MUST be a function that accepts a response object and returns a boolean indicating if the request is a success or failure
 
 #### `[RSAA].types`
 

--- a/README.md
+++ b/README.md
@@ -833,11 +833,12 @@ The `[RSAA]` property MAY
 - have an `options` property,
 - have a `credentials` property,
 - have a `bailout` property,
-- have a `fetch` property.
+- have a `fetch` property,
+- have an `ok` property.
 
 The `[RSAA]` property MUST NOT
 
-- include properties other than `endpoint`, `method`, `types`, `body`, `headers`, `options`, `credentials`, `bailout` and `fetch`.
+- include properties other than `endpoint`, `method`, `types`, `body`, `headers`, `options`, `credentials`, `bailout`, `fetch` and `ok`.
 
 #### `[RSAA].endpoint`
 

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,6 +1,0 @@
-const defaults = {
-  ok: res => res.ok,
-  fetch
-};
-
-export default defaults;

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,0 +1,6 @@
+const defaults = {
+  ok: res => res.ok,
+  fetch
+};
+
+export default defaults;

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@
  * @exports {error} RequestError
  * @exports {error} ApiError
  * @exports {function} getJSON
+ * @exports {function} createMiddleware
  * @exports {ReduxMiddleWare} apiMiddleware
  */
 

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ import RSAA from './RSAA';
 import { isRSAA, validateRSAA, isValidRSAA } from './validation';
 import { InvalidRSAA, InternalError, RequestError, ApiError } from './errors';
 import { getJSON } from './util';
-import { apiMiddleware } from './middleware';
+import { apiMiddleware, createMiddleware } from './middleware';
 
 export {
   RSAA,
@@ -44,5 +44,6 @@ export {
   RequestError,
   ApiError,
   getJSON,
+  createMiddleware,
   apiMiddleware
 };

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -193,7 +193,7 @@ function createMiddleware(options = {}) {
 
       let isOk;
       try {
-        isOk = ok(res)
+        isOk = ok(res);
       } catch (e) {
         return next(
           await actionWith(

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -2,8 +2,25 @@ import RSAA from './RSAA';
 import { isRSAA, validateRSAA } from './validation';
 import { InvalidRSAA, RequestError } from './errors';
 import { normalizeTypeDescriptors, actionWith } from './util';
-import defaults from './defaults';
 
+/**
+ * Default options for redux-api-middleware
+ * These can be customized by passing options into `createMiddleware`
+ * @type {Object}
+ */
+const defaults = {
+  ok: res => res.ok,
+  fetch
+};
+
+/**
+ * A middleware creator used to create a ReduxApiMiddleware
+ * with custom defaults
+ *
+ * @type {function}
+ * @returns {ReduxMiddleware}
+ * @access public
+ */
 function createMiddleware(options = {}) {
   const middlewareOptions = Object.assign({}, defaults, options);
 

--- a/src/validation.js
+++ b/src/validation.js
@@ -61,7 +61,8 @@ function validateRSAA(action) {
     'credentials',
     'bailout',
     'types',
-    'fetch'
+    'fetch',
+    'ok'
   ];
   const validMethods = [
     'GET',
@@ -105,7 +106,8 @@ function validateRSAA(action) {
     credentials,
     types,
     bailout,
-    fetch
+    fetch,
+    ok
   } = callAPI;
   if (typeof endpoint === 'undefined') {
     validationErrors.push('[RSAA] must have an endpoint property');
@@ -191,6 +193,12 @@ function validateRSAA(action) {
   if (typeof fetch !== 'undefined') {
     if (typeof fetch !== 'function') {
       validationErrors.push('[RSAA].fetch property must be a function');
+    }
+  }
+
+  if (typeof ok !== 'undefined') {
+    if (typeof ok !== 'function') {
+      validationErrors.push('[RSAA].ok property must be a function');
     }
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -13,7 +13,8 @@ import {
   RequestError,
   ApiError,
   getJSON,
-  apiMiddleware
+  apiMiddleware,
+  createMiddleware
 } from '../src';
 
 // Private module exports
@@ -551,6 +552,19 @@ test('validateRSAA/isValidRSAA must identify conformant RSAAs', t => {
     '[RSAA].fetch property must be a function (isRSAA)'
   );
 
+  const action29 = {
+    [RSAA]: {
+      endpoint: '',
+      method: 'GET',
+      types: ['REQUEST', 'SUCCESS', 'FAILURE'],
+      ok: {}
+    }
+  };
+  t.notOk(
+    isValidRSAA(action29),
+    '[RSAA].ok property must be a function (isRSAA)'
+  );
+
   t.end();
 });
 
@@ -821,6 +835,34 @@ test('actionWith', async t => {
     fsa4.error,
     'must set FSA error property to true if a custom meta function throws'
   );
+
+  t.end();
+});
+
+test('createMiddleware must return a Redux middleware', t => {
+  const doGetState = () => {};
+  const middleware = createMiddleware();
+  const nextHandler = middleware({ getState: doGetState });
+  const doNext = () => {};
+  const actionHandler = nextHandler(doNext);
+
+  t.equal(middleware.length, 1, 'apiMiddleware must take one argument');
+
+  t.equal(
+    typeof nextHandler,
+    'function',
+    'apiMiddleware must return a function to handle next'
+  );
+
+  t.equal(nextHandler.length, 1, 'next handler must take one argument');
+
+  t.equal(
+    typeof actionHandler,
+    'function',
+    'next handler must return a function to handle action'
+  );
+
+  t.equal(actionHandler.length, 1, 'action handler must take one argument');
 
   t.end();
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1171,7 +1171,54 @@ test('apiMiddleware must dispatch an error request FSA when [RSAA].options fails
   actionHandler(anAction);
 });
 
-test('apiMiddleware must dispatch an failure FSA with an error on a request error', t => {
+test('apiMiddleware must dispatch a failure FSA when [RSAA].ok fails', t => {
+  const api = nock('http://127.0.0.1')
+    .get('/api/users/1')
+    .reply(200);
+
+  const anAction = {
+    [RSAA]: {
+      endpoint: 'http://127.0.0.1/api/users/1',
+      method: 'GET',
+      ok: () => {
+        throw new Error();
+      },
+      types: [
+        'REQUEST',
+        'SUCCESS',
+        'FAILURE'
+      ]
+    }
+  };
+  const doGetState = () => {};
+  const nextHandler = apiMiddleware({ getState: doGetState });
+
+  const doNext = action => {
+    switch (action.type) {
+      case 'REQUEST':
+        t.pass('next handler called');
+        break;
+      case 'SUCCESS':
+        t.fail('success action should not be dispatched');
+        break;
+      case 'FAILURE':
+        t.equal(
+          action.payload.message,
+          '[RSAA].ok function failed',
+          'dispatched FSA has correct payload property'
+        );
+        t.ok(action.error, 'dispatched FSA has correct error property');
+        break;
+    }
+  };
+
+  const actionHandler = nextHandler(doNext);
+
+  t.plan(3);
+  actionHandler(anAction);
+});
+
+test('apiMiddleware must dispatch a failure FSA with an error on a request error', t => {
   const anAction = {
     [RSAA]: {
       endpoint: 'http://127.0.0.1/api/users/1', // We haven't mocked this
@@ -1374,6 +1421,173 @@ test('apiMiddleware must use an [RSAA].options function when present', t => {
   const actionHandler = nextHandler(doNext);
 
   t.plan(1);
+  actionHandler(anAction);
+});
+
+test('apiMiddleware must use an [RSAA].ok function when present', t => {
+  const api = nock('http://127.0.0.1')
+    .get('/api/users/1')
+    .reply(200);
+  const anAction = {
+    [RSAA]: {
+      endpoint: 'http://127.0.0.1/api/users/1',
+      method: 'GET',
+      ok: () => {
+        t.pass('[RSAA].ok function called');
+        return true
+      },
+      types: ['REQUEST', 'SUCCESS', 'FAILURE']
+    }
+  };
+  const doGetState = () => {};
+  const nextHandler = apiMiddleware({ getState: doGetState });
+  const doNext = action => {};
+  const actionHandler = nextHandler(doNext);
+
+  t.plan(1);
+  actionHandler(anAction);
+});
+
+test('apiMiddleware must dispatch a failure FSA when [RSAA].ok returns false on a successful request', t => {
+  const api = nock('http://127.0.0.1')
+    .get('/api/users/1')
+    .reply(200);
+  const anAction = {
+    [RSAA]: {
+      endpoint: 'http://127.0.0.1/api/users/1',
+      method: 'GET',
+      ok: () => {
+        return false
+      },
+      types: ['REQUEST', 'SUCCESS', 'FAILURE']
+    }
+  };
+  const doGetState = () => {};
+  const nextHandler = apiMiddleware({ getState: doGetState });
+  const doNext = action => {
+    switch (action.type) {
+      case 'REQUEST':
+        t.pass('next handler called');
+        break;
+      case 'SUCCESS':
+        t.fail('success action should not be dispatched');
+        break;
+      case 'FAILURE':
+        t.ok(action.error, 'dispatched FSA has correct error property');
+        break;
+    }
+  };
+  const actionHandler = nextHandler(doNext);
+
+  t.plan(2);
+  actionHandler(anAction);
+})
+
+test('apiMiddleware must use a [RSAA].fetch custom fetch wrapper when present', t => {
+  const asyncWorker = async () => 'Done!';
+  const responseBody = {
+    id: 1,
+    name: 'Alan',
+    error: false
+  };
+  const api = nock('http://127.0.0.1')
+    .get('/api/users/1')
+    .reply(200, responseBody);
+  const anAction = {
+    [RSAA]: {
+      endpoint: 'http://127.0.0.1/api/users/1',
+      method: 'GET',
+      fetch: async (endpoint, opts) => {
+        t.pass('custom fetch handler called');
+
+        // Simulate some async process like retrieving cache
+        await asyncWorker();
+
+        const res = await fetch(endpoint, opts);
+        const json = await res.json();
+
+        return new Response(
+          JSON.stringify({
+            ...json,
+            foo: 'bar'
+          }),
+          {
+            // Example of custom `res.ok`
+            status: json.error ? 500 : 200,
+            headers: {
+              'Content-Type': 'application/json'
+            }
+          }
+        );
+      },
+      types: ['REQUEST', 'SUCCESS', 'FAILURE']
+    }
+  };
+  const doGetState = () => {};
+  const nextHandler = apiMiddleware({ getState: doGetState });
+  const doNext = action => {
+    switch (action.type) {
+      case 'SUCCESS':
+        t.deepEqual(
+          action.payload,
+          {
+            ...responseBody,
+            foo: 'bar'
+          },
+          'custom response passed to the next handler'
+        );
+        break;
+    }
+  };
+
+  const actionHandler = nextHandler(doNext);
+
+  t.plan(2);
+  actionHandler(anAction);
+});
+
+test('apiMiddleware must dispatch correct error payload when custom fetch wrapper returns an error response', t => {
+  const anAction = {
+    [RSAA]: {
+      endpoint: 'http://127.0.0.1/api/users/1',
+      method: 'GET',
+      fetch: async (endpoint, opts) => {
+        return new Response(
+          JSON.stringify({
+            foo: 'bar'
+          }),
+          {
+            status: 500,
+            headers: {
+              'Content-Type': 'application/json'
+            }
+          }
+        );
+      },
+      types: ['REQUEST', 'SUCCESS', 'FAILURE']
+    }
+  };
+  const doGetState = () => {};
+  const nextHandler = apiMiddleware({ getState: doGetState });
+  const doNext = action => {
+    switch (action.type) {
+      case 'FAILURE':
+        t.ok(action.payload instanceof Error);
+        t.pass('error action dispatched');
+        t.deepEqual(
+          action.payload.response,
+          {
+            foo: 'bar'
+          },
+          'custom response passed to the next handler'
+        );
+        break;
+    }
+  };
+
+  const actionHandler = nextHandler(doNext);
+
+  t.plan(3);
   actionHandler(anAction);
 });
 
@@ -1936,113 +2150,5 @@ test('apiMiddleware must dispatch a failure FSA on an unsuccessful API call with
   const actionHandler = nextHandler(doNext);
 
   t.plan(8);
-  actionHandler(anAction);
-});
-
-test('apiMiddleware must use a [RSAA].fetch custom fetch wrapper when present', t => {
-  const asyncWorker = async () => 'Done!';
-  const responseBody = {
-    id: 1,
-    name: 'Alan',
-    error: false
-  };
-  const api = nock('http://127.0.0.1')
-    .get('/api/users/1')
-    .reply(200, responseBody);
-  const anAction = {
-    [RSAA]: {
-      endpoint: 'http://127.0.0.1/api/users/1',
-      method: 'GET',
-      fetch: async (endpoint, opts) => {
-        t.pass('custom fetch handler called');
-
-        // Simulate some async process like retrieving cache
-        await asyncWorker();
-
-        const res = await fetch(endpoint, opts);
-        const json = await res.json();
-
-        return new Response(
-          JSON.stringify({
-            ...json,
-            foo: 'bar'
-          }),
-          {
-            // Example of custom `res.ok`
-            status: json.error ? 500 : 200,
-            headers: {
-              'Content-Type': 'application/json'
-            }
-          }
-        );
-      },
-      types: ['REQUEST', 'SUCCESS', 'FAILURE']
-    }
-  };
-  const doGetState = () => {};
-  const nextHandler = apiMiddleware({ getState: doGetState });
-  const doNext = action => {
-    switch (action.type) {
-      case 'SUCCESS':
-        t.deepEqual(
-          action.payload,
-          {
-            ...responseBody,
-            foo: 'bar'
-          },
-          'custom response passed to the next handler'
-        );
-        break;
-    }
-  };
-
-  const actionHandler = nextHandler(doNext);
-
-  t.plan(2);
-  actionHandler(anAction);
-});
-
-test('apiMiddleware must dispatch correct error payload when custom fetch wrapper returns an error response', t => {
-  const anAction = {
-    [RSAA]: {
-      endpoint: 'http://127.0.0.1/api/users/1',
-      method: 'GET',
-      fetch: async (endpoint, opts) => {
-        return new Response(
-          JSON.stringify({
-            foo: 'bar'
-          }),
-          {
-            status: 500,
-            headers: {
-              'Content-Type': 'application/json'
-            }
-          }
-        );
-      },
-      types: ['REQUEST', 'SUCCESS', 'FAILURE']
-    }
-  };
-  const doGetState = () => {};
-  const nextHandler = apiMiddleware({ getState: doGetState });
-  const doNext = action => {
-    switch (action.type) {
-      case 'FAILURE':
-        t.ok(action.payload instanceof Error);
-        t.pass('error action dispatched');
-        t.deepEqual(
-          action.payload.response,
-          {
-            foo: 'bar'
-          },
-          'custom response passed to the next handler'
-        );
-        break;
-    }
-  };
-
-  const actionHandler = nextHandler(doNext);
-
-  t.plan(3);
   actionHandler(anAction);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1183,11 +1183,7 @@ test('apiMiddleware must dispatch a failure FSA when [RSAA].ok fails', t => {
       ok: () => {
         throw new Error();
       },
-      types: [
-        'REQUEST',
-        'SUCCESS',
-        'FAILURE'
-      ]
+      types: ['REQUEST', 'SUCCESS', 'FAILURE']
     }
   };
   const doGetState = () => {};
@@ -1434,7 +1430,7 @@ test('apiMiddleware must use an [RSAA].ok function when present', t => {
       method: 'GET',
       ok: () => {
         t.pass('[RSAA].ok function called');
-        return true
+        return true;
       },
       types: ['REQUEST', 'SUCCESS', 'FAILURE']
     }
@@ -1457,7 +1453,7 @@ test('apiMiddleware must dispatch a failure FSA when [RSAA].ok returns false on 
       endpoint: 'http://127.0.0.1/api/users/1',
       method: 'GET',
       ok: () => {
-        return false
+        return false;
       },
       types: ['REQUEST', 'SUCCESS', 'FAILURE']
     }
@@ -1481,7 +1477,7 @@ test('apiMiddleware must dispatch a failure FSA when [RSAA].ok returns false on 
 
   t.plan(2);
   actionHandler(anAction);
-})
+});
 
 test('apiMiddleware must use a [RSAA].fetch custom fetch wrapper when present', t => {
   const asyncWorker = async () => 'Done!';


### PR DESCRIPTION
Picks up from @iamandrewluca's #171 and:

- rebases from + targets `next` branch
- adds tests
- adds docs
- adds error handling around `ok` function