### PR TITLE
#199: only await if custom payload/meta is a function

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -70,18 +70,20 @@ function normalizeTypeDescriptors(types) {
  */
 async function actionWith(descriptor, args) {
   try {
-    descriptor.payload = await (typeof descriptor.payload === 'function'
-      ? descriptor.payload(...args)
-      : descriptor.payload);
+    descriptor.payload =
+      typeof descriptor.payload === 'function'
+        ? await descriptor.payload(...args)
+        : descriptor.payload;
   } catch (e) {
     descriptor.payload = new InternalError(e.message);
     descriptor.error = true;
   }
 
   try {
-    descriptor.meta = await (typeof descriptor.meta === 'function'
-      ? descriptor.meta(...args)
-      : descriptor.meta);
+    descriptor.meta =
+      typeof descriptor.meta === 'function'
+        ? await descriptor.meta(...args)
+        : descriptor.meta;
   } catch (e) {
     delete descriptor.meta;
     descriptor.payload = new InternalError(e.message);


### PR DESCRIPTION
Fixes https://github.com/agraboso/redux-api-middleware/issues/199

@nason let me know if I am missing a reason to await the typeof check...tests seemed to pass and it worked fine for my project :)

Resulting transpiled code:
```js
try {
  return new Promise(function($return, $error) {
    if (typeof descriptor.meta === "function") {
      return descriptor.meta.apply(descriptor, args).then($return, $error);
    }
    return $return(descriptor.meta);
  }).then(function($await_11) {
    try {
      descriptor.meta = $await_11;
      return $Try_2_Post();
    } catch ($boundEx) {
      return $Try_2_Catch($boundEx);
    }
  }, $Try_2_Catch);
} catch (e) {
  $Try_2_Catch(e);
}
```