### PR TITLE
Bundle updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -193,6 +193,18 @@
       "integrity": "sha512-LAQ1d4OPfSJ/BMbI2DuizmYrrkD9JMaTdi2hQTlI53lQ4kRQPyZQRS4CYQ7O66bnBBnP/oYdRxbk++X0xuFU6A==",
       "dev": true
     },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.2.tgz",
+      "integrity": "sha512-m9zXmifkZsMHZBOyxZWilMwmTlpC8x5Ty360JKTiXvlXZfBWYpsg9ZZvP/Ye+iZUh+Q+MxDLjItVTWIsfwz+8Q==",
+      "dev": true
+    },
     "@vue/component-compiler-utils": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-1.3.1.tgz",
@@ -241,9 +253,9 @@
           }
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -269,12 +281,6 @@
             "indexes-of": "^1.0.1",
             "uniq": "^1.0.1"
           }
-        },
-        "prettier": {
-          "version": "1.13.5",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.5.tgz",
-          "integrity": "sha512-4M90mfvLz6yRf2Dhzd+xPIE6b4xkI8nHMJhsSm9IlfG17g6wujrrm7+H1X8x52tC4cSNm6HmuhCUSNe6Hd5wfw==",
-          "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
@@ -584,15 +590,6 @@
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
-      }
-    },
-    "acorn5-object-spread": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn5-object-spread/-/acorn5-object-spread-4.0.0.tgz",
-      "integrity": "sha1-1XWAge7ZcSGrC+R+Mcqu8qo5lpc=",
-      "dev": true,
-      "requires": {
-        "acorn": "^5.1.2"
       }
     },
     "ajv": {
@@ -1826,21 +1823,30 @@
       }
     },
     "buble": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/buble/-/buble-0.18.0.tgz",
-      "integrity": "sha512-U3NJxUiSz0H1EB54PEHAuBTxdXgQH4DaQkvkINFXf9kEKCDWSn67EgQfFKbkTzsok4xRrIPsoxWDl2czCHR65g==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.3.tgz",
+      "integrity": "sha512-3B0Lcy2u6x6km0BqTz/FS3UnrOJlnIlBWsyjvtqzdtmWkqiS0+Sg4hc6L9Mmm63hZKTACpYS9vUeIoKSi1vcrQ==",
       "dev": true,
       "requires": {
-        "acorn": "^5.1.2",
-        "acorn-jsx": "^3.0.1",
-        "acorn5-object-spread": "^4.0.0",
-        "chalk": "^2.1.0",
+        "acorn": "^5.4.1",
+        "acorn-dynamic-import": "^3.0.0",
+        "acorn-jsx": "^4.1.1",
+        "chalk": "^2.3.1",
         "magic-string": "^0.22.4",
         "minimist": "^1.2.0",
         "os-homedir": "^1.0.1",
-        "vlq": "^0.2.2"
+        "vlq": "^1.0.0"
       },
       "dependencies": {
+        "acorn-jsx": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-4.1.1.tgz",
+          "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
+          "dev": true,
+          "requires": {
+            "acorn": "^5.0.3"
+          }
+        },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -2000,6 +2006,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
       "dev": true
     },
     "caniuse-api": {
@@ -3102,20 +3114,11 @@
         "is-symbol": "^1.0.1"
       }
     },
-    "es6-promise": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-      "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ==",
-      "dev": true
-    },
     "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "^4.0.3"
-      }
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.0.tgz",
+      "integrity": "sha512-8Tbqjrb8lC85dd81haajYwuRmiU2rkqNAFnlvQOJeeKqdUloIlI+JcUqeJruV4rCm5Y7oNU7jfs2FbmxhRR/2g==",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -3939,6 +3942,14 @@
       "requires": {
         "babylon": "^6.15.0",
         "vlq": "^0.2.1"
+      },
+      "dependencies": {
+        "vlq": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+          "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+          "dev": true
+        }
       }
     },
     "flush-write-stream": {
@@ -4706,6 +4717,12 @@
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
+    "globalyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
+    },
     "globby": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
@@ -4719,6 +4736,12 @@
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
       }
+    },
+    "globrex": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.1.tgz",
+      "integrity": "sha512-bqKcPhb+ZtrISivpu6oLmwIyINlPlzueO/BDCdfnzUeu7SYxnHTXmWP7uQI5PnQXc5yGXOscGBEGagloA2hcSw==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -5789,6 +5812,14 @@
       "dev": true,
       "requires": {
         "vlq": "^0.2.2"
+      },
+      "dependencies": {
+        "vlq": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+          "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+          "dev": true
+        }
       }
     },
     "make-dir": {
@@ -5954,39 +5985,40 @@
       "dev": true
     },
     "microbundle": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/microbundle/-/microbundle-0.4.4.tgz",
-      "integrity": "sha512-pjOigeyzxelTbI3eY6vBWMwo+gZlluqEmLAbiTJFgZ0/IOLDJQC9fFSvHztkO0MdQ5ufaJTekBO2AnAq/XUtGA==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/microbundle/-/microbundle-0.5.1.tgz",
+      "integrity": "sha512-ZzLXsX1Xwh1Oq4Ss923e04i/DySacyJZf5jBsbjQE+RjR9N5kI4+3ehAw40yrq7krmWT/lEOntc4TOUuhh+eyw==",
       "dev": true,
       "requires": {
         "acorn-jsx": "^4.1.1",
         "asyncro": "^3.0.0",
-        "autoprefixer": "^7.2.5",
+        "autoprefixer": "^8.3.0",
         "babel-polyfill": "^6.26.0",
-        "camelcase": "^4.1.0",
-        "chalk": "^2.3.0",
-        "es6-promisify": "^5.0.0",
-        "glob": "^7.1.2",
+        "camelcase": "^5.0.0",
+        "chalk": "^2.4.0",
+        "cssnano": "^3.10.0",
+        "es6-promisify": "^6.0.0",
         "gzip-size": "^4.1.0",
-        "pretty-bytes": "^4.0.2",
+        "pretty-bytes": "^5.1.0",
         "regenerator-runtime": "^0.11.1",
-        "rollup": "^0.55.1",
-        "rollup-plugin-buble": "^0.18.0",
+        "rollup": "^0.62.0",
+        "rollup-plugin-buble": "^0.19.2",
         "rollup-plugin-bundle-size": "^1.0.1",
-        "rollup-plugin-commonjs": "^8.2.6",
+        "rollup-plugin-commonjs": "^9.0.0",
         "rollup-plugin-es3": "^1.1.0",
         "rollup-plugin-flow": "^1.1.1",
-        "rollup-plugin-node-resolve": "^3.0.2",
+        "rollup-plugin-node-resolve": "^3.3.0",
         "rollup-plugin-nodent": "^0.2.2",
-        "rollup-plugin-postcss": "^1.2.7",
+        "rollup-plugin-postcss": "^1.6.1",
         "rollup-plugin-preserve-shebang": "^0.1.6",
         "rollup-plugin-sizes": "^0.4.2",
         "rollup-plugin-strict-alias": "^1.0.0",
-        "rollup-plugin-typescript2": "^0.11",
+        "rollup-plugin-typescript2": "^0.13.0",
         "rollup-plugin-uglify": "^3.0.0",
-        "sade": "^1.3.1",
+        "sade": "^1.4.0",
+        "tiny-glob": "^0.2.0",
         "tslib": "^1.9.0",
-        "typescript": "^2.6.2"
+        "typescript": "^2.8.3"
       },
       "dependencies": {
         "acorn-jsx": {
@@ -6008,33 +6040,23 @@
           }
         },
         "autoprefixer": {
-          "version": "7.2.6",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.6.tgz",
-          "integrity": "sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==",
+          "version": "8.6.5",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.6.5.tgz",
+          "integrity": "sha512-PLWJN3Xo/rycNkx+mp8iBDMTm3FeWe4VmYaZDSqL5QQB9sLsQkG5k8n+LNDFnhh9kdq2K+egL/icpctOmDHwig==",
           "dev": true,
           "requires": {
-            "browserslist": "^2.11.3",
-            "caniuse-lite": "^1.0.30000805",
+            "browserslist": "^3.2.8",
+            "caniuse-lite": "^1.0.30000864",
             "normalize-range": "^0.1.2",
             "num2fraction": "^1.2.2",
-            "postcss": "^6.0.17",
+            "postcss": "^6.0.23",
             "postcss-value-parser": "^3.2.3"
           }
         },
-        "browserslist": {
-          "version": "2.11.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-          "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30000792",
-            "electron-to-chromium": "^1.3.30"
-          }
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+        "caniuse-lite": {
+          "version": "1.0.30000865",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz",
+          "integrity": "sha512-vs79o1mOSKRGv/1pSkp4EXgl4ZviWeYReXw60XfacPU64uQWZwJT6vZNmxRF9O+6zu71sJwMxLK5JXxbzuVrLw==",
           "dev": true
         },
         "chalk": {
@@ -6049,9 +6071,9 @@
           }
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -9321,9 +9343,9 @@
           }
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -9716,9 +9738,9 @@
       "dev": true
     },
     "pretty-bytes": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
-      "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.1.0.tgz",
+      "integrity": "sha512-wa5+qGVg9Yt7PB6rYm3kXlKzgzgivYTLRandezh43jjRqgyDyP+9YxfJpJiLs9yKD1WeU8/OvtToWpW7255FtA==",
       "dev": true
     },
     "pretty-ms": {
@@ -10220,9 +10242,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.5"
@@ -10301,18 +10323,22 @@
       }
     },
     "rollup": {
-      "version": "0.55.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.55.5.tgz",
-      "integrity": "sha512-2hke9NOy332kxvnmMQOgl7DHm94zihNyYJNd8ZLWo4U0EjFvjUkeWa0+ge+70bTg+mY0xJ7NUsf5kIhDtrGrtA==",
-      "dev": true
-    },
-    "rollup-plugin-buble": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-buble/-/rollup-plugin-buble-0.18.0.tgz",
-      "integrity": "sha512-rd3JG2MxvQXfg5coCw0IyZV8QrsceVI4zfJgGVgkUnntwp+gnjv7TsKWGKGoLNMGAMRKQlhcsSyvUuvOL+vNHw==",
+      "version": "0.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.62.0.tgz",
+      "integrity": "sha512-mZS0aIGfYzuJySJD78znu9/hCJsNfBzg4lDuZGMj0hFVcYHt2evNRHv8aqiu9/w6z6Qn8AQoVl4iyEjDmisGeA==",
       "dev": true,
       "requires": {
-        "buble": "^0.18.0",
+        "@types/estree": "0.0.39",
+        "@types/node": "*"
+      }
+    },
+    "rollup-plugin-buble": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-buble/-/rollup-plugin-buble-0.19.2.tgz",
+      "integrity": "sha512-dxK0prR8j/7qhI2EZDz/evKCRuhuZMpRlUGPrRWmpg5/2V8tP1XFW+Uk0WfxyNgFfJHvy0GmxnJSTb5dIaNljQ==",
+      "dev": true,
+      "requires": {
+        "buble": "^0.19.2",
         "rollup-pluginutils": "^2.0.1"
       }
     },
@@ -10327,15 +10353,14 @@
       }
     },
     "rollup-plugin-commonjs": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.4.1.tgz",
-      "integrity": "sha512-mg+WuD+jlwoo8bJtW3Mvx7Tz6TsIdMsdhuvCnDMoyjh0oxsVgsjB/N0X984RJCWwc5IIiqNVJhXeeITcc73++A==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.1.3.tgz",
+      "integrity": "sha512-g91ZZKZwTW7F7vL6jMee38I8coj/Q9GBdTmXXeFL7ldgC1Ky5WJvHgbKlAiXXTh762qvohhExwUgeQGFh9suGg==",
       "dev": true,
       "requires": {
-        "acorn": "^5.2.1",
-        "estree-walker": "^0.5.0",
+        "estree-walker": "^0.5.1",
         "magic-string": "^0.22.4",
-        "resolve": "^1.4.0",
+        "resolve": "^1.5.0",
         "rollup-pluginutils": "^2.0.1"
       }
     },
@@ -10457,9 +10482,9 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.1",
@@ -10512,13 +10537,13 @@
       "dev": true
     },
     "rollup-plugin-typescript2": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.11.1.tgz",
-      "integrity": "sha512-slniBE8s9mkLfE3PIcy8xT3utV8oofYqOMBTxMVvkyFz3FNslLJ1ssEdZpWsB7A52+awpqIwjjWXH5e/4/i6dQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.13.0.tgz",
+      "integrity": "sha512-E+NgtKWuT7QaQAjWz9KKFqC+aoBRR9HeiN/N2EJcAzGggqpcK+jLJGeqnyq+/g0ptaVQCzkyDGhqG0skSn4JHg==",
       "dev": true,
       "requires": {
         "fs-extra": "^5.0.0",
-        "resolve": "^1.5.0",
+        "resolve": "^1.7.1",
         "rollup-pluginutils": "^2.0.1",
         "tslib": "^1.9.0"
       }
@@ -11980,6 +12005,16 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-glob": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.2.tgz",
+      "integrity": "sha512-o8rak1FRmr55Nd1Bdcfd+yetPGclFCVHXiKmoBHYULc+FQXBbqb9S3zKAWyqk+RdWvutlGUOw0kCHC0JLF/T4Q==",
+      "dev": true,
+      "requires": {
+        "globalyzer": "^0.1.0",
+        "globrex": "^0.1.1"
+      }
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -12265,9 +12300,9 @@
       }
     },
     "universalify": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "unpipe": {
@@ -12462,9 +12497,9 @@
       }
     },
     "vlq": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.0.tgz",
+      "integrity": "sha512-o3WmXySo+oI5thgqr7Qy8uBkT/v9Zr+sRyrh1lr8aWPUkgDWdWt4Nae2WKBrLsocgE8BuWWD0jLc+VW8LeU+2g==",
       "dev": true
     },
     "vm-browserify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5751,11 +5751,6 @@
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
       "dev": true
     },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,7 @@
     "email": "agraboso@gmail.com"
   },
   "license": "MIT",
-  "dependencies": {
-    "lodash.isplainobject": "^4.0.6"
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-plugin-istanbul": "^4.1.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint": "^4.19.1",
     "eslint-plugin-prettier": "^2.6.0",
     "isomorphic-fetch": "^2.2.1",
-    "microbundle": "^0.4.4",
+    "microbundle": "^0.5.1",
     "nock": "^9.3.3",
     "nyc": "^12.0.2",
     "prettier": "^1.13.5",

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,5 +1,20 @@
 import RSAA from './RSAA';
-import isPlainObject from 'lodash.isplainobject';
+
+/**
+ * Is the argument a plain object?
+ * Inspired by lodash.isplainobject
+ *
+ * @function isPlainObject
+ * @param {object} obj - The object to check
+ * @returns {boolean}
+ */
+function isPlainObject(obj) {
+  return (
+    obj &&
+    typeof obj == 'object' &&
+    Object.getPrototypeOf(obj) === Object.prototype
+  );
+}
 
 /**
  * Is the given action a plain JavaScript object with an [RSAA] property?


### PR DESCRIPTION
Removing `lodash.isplainobject` dependency to further slim the bundle and to address https://github.com/agraboso/redux-api-middleware/issues/196