### PR TITLE
Add test case for descriptor with meta + payload functions

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -68,7 +68,7 @@ function normalizeTypeDescriptors(types) {
  * @param {array} args - The array of arguments for `payload` and `meta` function properties
  * @returns {object}
  */
-async function actionWith(descriptor, args) {
+async function actionWith(descriptor, args = []) {
   try {
     descriptor.payload =
       typeof descriptor.payload === 'function'

--- a/test/index.js
+++ b/test/index.js
@@ -868,6 +868,33 @@ test('actionWith', async t => {
     'must set FSA error property to true if a custom meta function throws'
   );
 
+  const descriptor5 = {
+    type: 'REQUEST',
+    payload: () => 'somePayload',
+    meta: () => new Promise(resolve => setTimeout(() => resolve('someMeta'), 250)),
+    error: true
+  };
+  const fsa5 = await actionWith(descriptor5);
+  t.equal(
+    fsa5.type,
+    'REQUEST',
+    'must set FSA type property to incoming descriptor type property'
+  );
+  t.equal(
+    fsa5.payload,
+    'somePayload',
+    'must set FSA payload property to incoming descriptor payload property'
+  );
+  t.equal(
+    fsa5.meta,
+    'someMeta',
+    'must set FSA meta property to incoming descriptor meta property'
+  );
+  t.ok(
+    fsa5.error,
+    'must set FSA error property to incoming descriptor error property'
+  );
+
   t.end();
 });
 


### PR DESCRIPTION
Follow up to https://github.com/agraboso/redux-api-middleware/issues/199#issuecomment-404960106 and #200 

@ztanner I added a test case here to make sure non-async and async functions were being handled in `awaitWith`. What do you think?

Seems ok here, but I'm thinking that it may be worth running the bundled code in `lib` through some tests too