### PR TITLE
Support Opaque Responses

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -176,7 +176,7 @@ function apiMiddleware({ getState }) {
       }
 
       // Process the server response
-      if (res.ok) {
+      if (res.ok || res.type === 'opaque') {
         return next(await actionWith(successType, [action, getState(), res]));
       } else {
         return next(


### PR DESCRIPTION
Requests with `mode: 'no-cors'` return opaque responses, which aren't failures, but do have a status code of 0 AKA `!res.ok`.

See: 
https://fetch.spec.whatwg.org/#concept-filtered-response-opaque