### PR TITLE
Clone the response object before passing to payload/meta functions

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -13,7 +13,7 @@
   {
     "name": "lib/index.umd.js (min)",
     "path": "lib/index.umd.js",
-    "limit": "30 KB",
+    "limit": "31 KB",
     "gzip": false
   },
   {

--- a/src/__snapshots__/middleware.test.js.snap
+++ b/src/__snapshots__/middleware.test.js.snap
@@ -309,7 +309,7 @@ exports[`#apiMiddleware must dispatch a failure FSA when [RSAA].ok returns false
         "timeout": 0,
         Symbol(Body internals): Object {
           "body": "{\\"data\\":\\"12345\\"}",
-          "disturbed": true,
+          "disturbed": false,
           "error": null,
         },
         Symbol(Response internals): Object {
@@ -1533,7 +1533,7 @@ exports[`#apiMiddleware must use an [RSAA].ok function when present: ok() 1`] = 
         "timeout": 0,
         Symbol(Body internals): Object {
           "body": "{\\"data\\":\\"12345\\"}",
-          "disturbed": true,
+          "disturbed": false,
           "error": null,
         },
         Symbol(Response internals): Object {

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -202,14 +202,14 @@ function createMiddleware(options = {}) {
               payload: new InternalError('[RSAA].ok function failed'),
               error: true
             },
-            [action, getState(), res]
+            [action, getState(), res.clone()]
           )
         );
       }
 
       // Process the server response
       if (isOk) {
-        return next(await actionWith(successType, [action, getState(), res]));
+        return next(await actionWith(successType, [action, getState(), res.clone()]));
       } else {
         return next(
           await actionWith(
@@ -217,7 +217,7 @@ function createMiddleware(options = {}) {
               ...failureType,
               error: true
             },
-            [action, getState(), res]
+            [action, getState(), res.clone()]
           )
         );
       }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -202,14 +202,14 @@ function createMiddleware(options = {}) {
               payload: new InternalError('[RSAA].ok function failed'),
               error: true
             },
-            [action, getState(), res.clone()]
+            [action, getState(), res]
           )
         );
       }
 
       // Process the server response
       if (isOk) {
-        return next(await actionWith(successType, [action, getState(), res.clone()]));
+        return next(await actionWith(successType, [action, getState(), res]));
       } else {
         return next(
           await actionWith(
@@ -217,7 +217,7 @@ function createMiddleware(options = {}) {
               ...failureType,
               error: true
             },
-            [action, getState(), res.clone()]
+            [action, getState(), res]
           )
         );
       }

--- a/src/util.js
+++ b/src/util.js
@@ -60,6 +60,19 @@ function normalizeTypeDescriptors(types) {
 }
 
 /**
+ * Makes argument lists safe to pass to callbacks by cloning responses
+ * so that multiple callbacks may read the body
+ *
+ * @function safeResponseArgs
+ * @access private
+ * @param {array} args - The array of arguments to be processed
+ * @returns {array}
+ */
+function safeResponseArgs(args = []) {
+  return args.map(arg => arg instanceof Response ? arg.clone() : arg);
+}
+
+/**
  * Evaluate a type descriptor to an FSA
  *
  * @function actionWith
@@ -72,7 +85,7 @@ async function actionWith(descriptor, args = []) {
   try {
     descriptor.payload =
       typeof descriptor.payload === 'function'
-        ? await descriptor.payload(...args)
+        ? await descriptor.payload(...safeResponseArgs(args))
         : descriptor.payload;
   } catch (e) {
     descriptor.payload = new InternalError(e.message);
@@ -82,7 +95,7 @@ async function actionWith(descriptor, args = []) {
   try {
     descriptor.meta =
       typeof descriptor.meta === 'function'
-        ? await descriptor.meta(...args)
+        ? await descriptor.meta(...safeResponseArgs(args))
         : descriptor.meta;
   } catch (e) {
     delete descriptor.meta;

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -136,6 +136,14 @@ describe('#actionWith', () => {
 
     expect(fsa).toMatchSnapshot();
   });
+
+  it('allows both meta and payload functions to read the response body', async () => {
+    const fsa = await actionWith({
+      type: 'SUCCESS',
+      meta: (action, state, request) => request.text(), 
+      payload: (action, state, request) => request.text() 
+    }, [0, 0, new Response()]);
+  });
 });
 
 describe('#getJSON', () => {


### PR DESCRIPTION
When implementing meta functions, one must currently create a clone of the response object in order to read the response body. To do *that*, they must also implement the payload function, clone the response, and return the json. This behavior has been documented a few times that I've found so far:
- https://github.com/agraboso/redux-api-middleware/issues/134
- https://github.com/agraboso/redux-api-middleware/issues/92

By calling those functions using the clone, we avoid this issue.

## Notes:
- I had to update the test snapshots because the `ReadableStream` are no longer marked as [disturbed](https://streams.spec.whatwg.org/#is-readable-stream-disturbed) after cloning.