### PR TITLE
add support for async RSAA properties

### DIFF
--- a/src/__snapshots__/middleware.test.js.snap
+++ b/src/__snapshots__/middleware.test.js.snap
@@ -1651,6 +1651,372 @@ exports[`#apiMiddleware must use an [RSAA].options function when present: option
 }
 `;
 
+exports[`#apiMiddleware must use an async [RSAA].body function when present: body() 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      undefined,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`#apiMiddleware must use an async [RSAA].body function when present: fetch mock 1`] = `
+Object {
+  "calls": Array [
+    Array [
+      "http://127.0.0.1/api/users/1",
+      Object {
+        "body": "mockBody",
+        "credentials": undefined,
+        "headers": Object {},
+        "method": "GET",
+      },
+    ],
+  ],
+  "instances": Array [
+    undefined,
+  ],
+  "invocationCallOrder": Any<Object>,
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`#apiMiddleware must use an async [RSAA].body function when present: final result 1`] = `
+Object {
+  "meta": undefined,
+  "payload": Object {
+    "data": "12345",
+  },
+  "type": "SUCCESS",
+}
+`;
+
+exports[`#apiMiddleware must use an async [RSAA].body function when present: next mock 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "type": "REQUEST",
+      },
+    ],
+    Array [
+      Object {
+        "meta": undefined,
+        "payload": Object {
+          "data": "12345",
+        },
+        "type": "SUCCESS",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "type": "REQUEST",
+      },
+    },
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "meta": undefined,
+        "payload": Object {
+          "data": "12345",
+        },
+        "type": "SUCCESS",
+      },
+    },
+  ],
+}
+`;
+
+exports[`#apiMiddleware must use an async [RSAA].endpoint function when present: endpoint() 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      undefined,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`#apiMiddleware must use an async [RSAA].endpoint function when present: fetch mock 1`] = `
+Object {
+  "calls": Array [
+    Array [
+      "http://127.0.0.1/api/users/1",
+      Object {
+        "body": undefined,
+        "credentials": undefined,
+        "headers": Object {},
+        "method": "GET",
+      },
+    ],
+  ],
+  "instances": Array [
+    undefined,
+  ],
+  "invocationCallOrder": Any<Object>,
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`#apiMiddleware must use an async [RSAA].endpoint function when present: final result 1`] = `
+Object {
+  "meta": undefined,
+  "payload": Object {
+    "data": "12345",
+  },
+  "type": "SUCCESS",
+}
+`;
+
+exports[`#apiMiddleware must use an async [RSAA].endpoint function when present: next mock 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "type": "REQUEST",
+      },
+    ],
+    Array [
+      Object {
+        "meta": undefined,
+        "payload": Object {
+          "data": "12345",
+        },
+        "type": "SUCCESS",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "type": "REQUEST",
+      },
+    },
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "meta": undefined,
+        "payload": Object {
+          "data": "12345",
+        },
+        "type": "SUCCESS",
+      },
+    },
+  ],
+}
+`;
+
+exports[`#apiMiddleware must use an async [RSAA].headers function when present: fetch mock 1`] = `
+Object {
+  "calls": Array [
+    Array [
+      "http://127.0.0.1/api/users/1",
+      Object {
+        "body": undefined,
+        "credentials": undefined,
+        "headers": Object {
+          "Test-Header": "test",
+        },
+        "method": "GET",
+      },
+    ],
+  ],
+  "instances": Array [
+    undefined,
+  ],
+  "invocationCallOrder": Any<Object>,
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`#apiMiddleware must use an async [RSAA].headers function when present: final result 1`] = `
+Object {
+  "meta": undefined,
+  "payload": Object {
+    "data": "12345",
+  },
+  "type": "SUCCESS",
+}
+`;
+
+exports[`#apiMiddleware must use an async [RSAA].headers function when present: headers() 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      undefined,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`#apiMiddleware must use an async [RSAA].headers function when present: next mock 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "type": "REQUEST",
+      },
+    ],
+    Array [
+      Object {
+        "meta": undefined,
+        "payload": Object {
+          "data": "12345",
+        },
+        "type": "SUCCESS",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "type": "REQUEST",
+      },
+    },
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "meta": undefined,
+        "payload": Object {
+          "data": "12345",
+        },
+        "type": "SUCCESS",
+      },
+    },
+  ],
+}
+`;
+
+exports[`#apiMiddleware must use an async [RSAA].options function when present: fetch mock 1`] = `
+Object {
+  "calls": Array [
+    Array [
+      "http://127.0.0.1/api/users/1",
+      Object {
+        "body": undefined,
+        "credentials": undefined,
+        "headers": Object {},
+        "method": "GET",
+      },
+    ],
+  ],
+  "instances": Array [
+    undefined,
+  ],
+  "invocationCallOrder": Any<Object>,
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`#apiMiddleware must use an async [RSAA].options function when present: final result 1`] = `
+Object {
+  "meta": undefined,
+  "payload": Object {
+    "data": "12345",
+  },
+  "type": "SUCCESS",
+}
+`;
+
+exports[`#apiMiddleware must use an async [RSAA].options function when present: next mock 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "type": "REQUEST",
+      },
+    ],
+    Array [
+      Object {
+        "meta": undefined,
+        "payload": Object {
+          "data": "12345",
+        },
+        "type": "SUCCESS",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "type": "REQUEST",
+      },
+    },
+    Object {
+      "isThrow": false,
+      "value": Object {
+        "meta": undefined,
+        "payload": Object {
+          "data": "12345",
+        },
+        "type": "SUCCESS",
+      },
+    },
+  ],
+}
+`;
+
+exports[`#apiMiddleware must use an async [RSAA].options function when present: options() 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      undefined,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
 exports[`#apiMiddleware must use meta property of request type descriptor when it is a function: fetch mock 1`] = `
 Object {
   "calls": Array [

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -88,7 +88,7 @@ function createMiddleware(options = {}) {
       // Process [RSAA].endpoint function
       if (typeof endpoint === 'function') {
         try {
-          endpoint = endpoint(getState());
+          endpoint = await endpoint(getState());
         } catch (e) {
           return next(
             await actionWith(
@@ -106,7 +106,7 @@ function createMiddleware(options = {}) {
       // Process [RSAA].body function
       if (typeof body === 'function') {
         try {
-          body = body(getState());
+          body = await body(getState());
         } catch (e) {
           return next(
             await actionWith(
@@ -124,7 +124,7 @@ function createMiddleware(options = {}) {
       // Process [RSAA].headers function
       if (typeof headers === 'function') {
         try {
-          headers = headers(getState());
+          headers = await headers(getState());
         } catch (e) {
           return next(
             await actionWith(
@@ -142,7 +142,7 @@ function createMiddleware(options = {}) {
       // Process [RSAA].options function
       if (typeof options === 'function') {
         try {
-          options = options(getState());
+          options = await options(getState());
         } catch (e) {
           return next(
             await actionWith(

--- a/src/middleware.test.js
+++ b/src/middleware.test.js
@@ -402,9 +402,62 @@ describe('#apiMiddleware', () => {
     expect(body).toMatchSnapshot({}, 'body()');
   });
 
+  it('must use an async [RSAA].body function when present', async () => {
+    const body = jest.fn();
+    body.mockResolvedValue('mockBody');
+
+    const action = {
+      [RSAA]: {
+        endpoint: 'http://127.0.0.1/api/users/1',
+        method: 'GET',
+        types: ['REQUEST', 'SUCCESS', 'FAILURE'],
+        body
+      }
+    };
+
+    await doTestMiddleware({
+      action,
+      response: {
+        body: JSON.stringify({ data: '12345' }),
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    });
+
+    expect(body).toMatchSnapshot({}, 'body()');
+  });
+
   it('must use an [RSAA].endpoint function when present', async () => {
     const endpoint = jest.fn();
     endpoint.mockReturnValue('http://127.0.0.1/api/users/1');
+
+    const action = {
+      [RSAA]: {
+        endpoint,
+        method: 'GET',
+        types: ['REQUEST', 'SUCCESS', 'FAILURE']
+      }
+    };
+
+    await doTestMiddleware({
+      action,
+      response: {
+        body: JSON.stringify({ data: '12345' }),
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    });
+
+    expect(endpoint).toMatchSnapshot({}, 'endpoint()');
+  });
+
+  it('must use an async [RSAA].endpoint function when present', async () => {
+    const endpoint = jest.fn();
+    endpoint.mockResolvedValue('http://127.0.0.1/api/users/1');
 
     const action = {
       [RSAA]: {
@@ -455,9 +508,63 @@ describe('#apiMiddleware', () => {
     expect(headers).toMatchSnapshot({}, 'headers()');
   });
 
+  it('must use an async [RSAA].headers function when present', async () => {
+    const headers = jest.fn();
+    headers.mockResolvedValue({ 'Test-Header': 'test' });
+
+    const action = {
+      [RSAA]: {
+        endpoint: 'http://127.0.0.1/api/users/1',
+        method: 'GET',
+        types: ['REQUEST', 'SUCCESS', 'FAILURE'],
+        headers
+      }
+    };
+
+    await doTestMiddleware({
+      action,
+      response: {
+        body: JSON.stringify({ data: '12345' }),
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    });
+
+    expect(headers).toMatchSnapshot({}, 'headers()');
+  });
+
   it('must use an [RSAA].options function when present', async () => {
     const options = jest.fn();
     options.mockReturnValue({});
+
+    const action = {
+      [RSAA]: {
+        endpoint: 'http://127.0.0.1/api/users/1',
+        method: 'GET',
+        types: ['REQUEST', 'SUCCESS', 'FAILURE'],
+        options
+      }
+    };
+
+    await doTestMiddleware({
+      action,
+      response: {
+        body: JSON.stringify({ data: '12345' }),
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    });
+
+    expect(options).toMatchSnapshot({}, 'options()');
+  });
+
+  it('must use an async [RSAA].options function when present', async () => {
+    const options = jest.fn();
+    options.mockResolvedValue({});
 
     const action = {
       [RSAA]: {


### PR DESCRIPTION
When defining an RSAA action, you can define the properties of the RSAA action (body, headers, options) to be either a plain JavaScript object or a function.

If a function, the middleware executes the function to attain the result. The middleware that is executing the function is already an `async` function, so I added an `await` before the call of the above RSAA properties, so that async functions could be passed in and still evaluated.

To give a real-world example of why this is necessary: I store credentials for an API on the keychain in React-Native. I set the headers property to be a function that reads the keychain and formats the Authorization header. Accessing the keychain is done asynchronously. This change allows an async function to be used, and does not affect synchronous functions.