### PR TITLE
Fix default fetch function

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -10,7 +10,7 @@ import { normalizeTypeDescriptors, actionWith } from './util';
  */
 const defaults = {
   ok: res => res.ok,
-  fetch
+  fetch: global.fetch
 };
 
 /**


### PR DESCRIPTION
https://github.com/agraboso/redux-api-middleware/issues/219

This small change adds support for using this package in node environment