### PR TITLE
fix(middleware): use global fetch as last resort

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -9,8 +9,7 @@ import { normalizeTypeDescriptors, actionWith } from './util';
  * @type {Object}
  */
 const defaults = {
-  ok: res => res.ok,
-  fetch
+  ok: res => res.ok
 };
 
 /**
@@ -56,7 +55,7 @@ function createMiddleware(options = {}) {
         body,
         headers,
         options = {},
-        fetch: doFetch = middlewareOptions.fetch,
+        fetch: doFetch = middlewareOptions.fetch || fetch,
         ok = middlewareOptions.ok
       } = callAPI;
       const { method, credentials, bailout, types } = callAPI;
@@ -230,6 +229,7 @@ function createMiddleware(options = {}) {
  *
  * @type {ReduxMiddleware}
  * @access public
+ * @deprecated since v3.2.0 use `createMiddleware`
  */
 function apiMiddleware({ getState }) {
   return createMiddleware()({ getState });


### PR DESCRIPTION
This should behave like v2

In v2 global fetch was used at the moment when action was called. At that moment a global fetch was already provided. If fetch was not provided is was silently catch by try block and dispatched as an failure action.
In v3 we moved that global fetch as a default option. At that moment global fetch was not provided yet, and `'use strict';` complained that fetch does not exist.

Closes #241
Closes #219
Closes #249